### PR TITLE
chore: Pie Chart 나타날때 애니메이션 효과 추가

### DIFF
--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -60,7 +60,7 @@ export default class StatisticPage extends Component {
       onClick: (d: string) => {
         console.log('click: ' + d);
       },
-      radius: 125,
+      radius: 100,
     });
   }
 }

--- a/client/src/utils/PieChart.ts
+++ b/client/src/utils/PieChart.ts
@@ -1,9 +1,10 @@
 const defaultOption = {
   radius: 100,
-  hoverScaleRate: 1.3,
+  hoverScaleRate: 1.2,
   hoverEffectSpeed: 0.5,
   viewboxWidth: 400,
   viewboxHeight: 300,
+  animationDuration: 0.5,
 };
 
 export interface PiChartOption {
@@ -40,6 +41,7 @@ export default class PieChart {
       hoverEffectSpeed: 0.5,
       viewboxWidth: 400,
       viewboxHeight: 300,
+      animationDuration: 0.5,
       onClick: null,
     };
 
@@ -89,14 +91,14 @@ export default class PieChart {
       const pathData = [
         `M ${startX * r} ${startY * r}`,
         `A ${r} ${r} 0 ${largeArcFlag} 1 ${endX * r} ${endY * r}`,
-        `L 0,0Z`,
       ].join(' ');
 
       const pathEl = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
       pathEl.setAttribute('d', pathData);
-      if (entry.color) pathEl.setAttribute('fill', entry.color);
-      pathEl.setAttribute('stroke', 'white');
+      pathEl.setAttribute('fill', 'none');
+      if (entry.color) pathEl.setAttribute('stroke', entry.color);
+      pathEl.setAttribute('stroke-width', (r * 0.8).toString());
       pathEl.setAttribute('opacity', '0.7');
 
       pathEl.addEventListener('mouseover', () => {
@@ -123,6 +125,21 @@ export default class PieChart {
           }
         });
       }
+
+      const l = 2 * Math.PI * entry.percent * r;
+      pathEl.setAttribute('stroke-dasharray', `0 ${l} ${l} 0`);
+      pathEl.setAttribute('stroke-dashoffset', `${l}`);
+
+      const animateEl = document.createElementNS('http://www.w3.org/2000/svg', 'animate');
+
+      animateEl.setAttribute('attributeType', 'XML');
+      animateEl.setAttribute('attributeName', 'stroke-dashoffset');
+      animateEl.setAttribute('from', '0');
+      animateEl.setAttribute('to', `${l}`);
+      animateEl.setAttribute('dur', `${this.settings.animationDuration}s`);
+      animateEl.setAttribute('repeatCount', '1');
+      animateEl.setAttribute('fill', 'freeze');
+      pathEl.appendChild(animateEl);
 
       this.element.appendChild(pathEl);
     });


### PR DESCRIPTION
## 개요

Pie Chart 코드에서 SVG animation 태그를 추가했습니다.
css animation 과 같이 `<animate>`라는 태그를 통해 svg 애니메이션을 만들 수 있습니다.

## 변경사항

각 arc의 호 길이(`반지름 * 각도`)를 구해서  DashOffect를 변화주도록해서 애니메이션을 구현했습니다.
이 부분은 따로 문서화 해두겠습니다.

## 참고사항
## 추가 구현 필요사항
## 스크린샷

![Jul-28-2021 10-50-51](https://user-images.githubusercontent.com/20085849/127250856-a4eee4d1-4519-45e7-9080-98b1f05d6d4f.gif)

