### PR TITLE
[#35] feat: 결제 수단 추가를 위한 Wallet Page 완성

### DIFF
--- a/client/src/api/paymentTypeAPI.ts
+++ b/client/src/api/paymentTypeAPI.ts
@@ -1,0 +1,57 @@
+interface Result<D> {
+  success: boolean;
+  data: D;
+}
+
+export interface PaymentType {
+  id: number;
+  accountId: number;
+  name: string;
+  bgColor: string;
+  fontColor: string;
+  createAt: Date;
+  updateAt: Date;
+  image: string;
+}
+
+export const getPaymentTypesAsync = async (): Promise<Result<PaymentType[]>> => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve({
+        success: true,
+        data: [
+          {
+            id: 1,
+            accountId: 1,
+            name: 'Test Card',
+            bgColor: '#00ffff',
+            fontColor: '#ffffff',
+            createAt: new Date(),
+            updateAt: new Date(),
+            image: '',
+          },
+          {
+            id: 2,
+            accountId: 1,
+            name: 'Test Card',
+            bgColor: '#ff00ff',
+            fontColor: '#ffffff',
+            createAt: new Date(),
+            updateAt: new Date(),
+            image: '',
+          },
+          {
+            id: 3,
+            accountId: 1,
+            name: 'Test Card',
+            bgColor: '#ff0000',
+            fontColor: '#ffffff',
+            createAt: new Date(),
+            updateAt: new Date(),
+            image: '',
+          },
+        ],
+      });
+    }, 500);
+  });
+};

--- a/client/src/components/LedgerAddModal/CategorySelector/index.scss
+++ b/client/src/components/LedgerAddModal/CategorySelector/index.scss
@@ -7,12 +7,11 @@
   justify-content: center;
   align-self: center;
   &--toggle {
-    background-color: $primary;
-    color: white;
     border-radius: 999px;
     padding: 0.5em 1em;
     user-select: none;
     cursor: pointer;
+    color: $primary;
     border: 1px solid $primary;
     background-color: transparent;
     color: $primary;

--- a/client/src/components/LedgerAddModal/index.scss
+++ b/client/src/components/LedgerAddModal/index.scss
@@ -51,6 +51,7 @@
       background-color: transparent;
       flex-grow: 1;
       flex-shrink: 1;
+      color: inherit;
       border: none;
       outline: none;
     }

--- a/client/src/components/LedgerAddModal/index.scss
+++ b/client/src/components/LedgerAddModal/index.scss
@@ -4,8 +4,8 @@
   position: fixed;
   left: 0;
   top: 0;
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(3px);
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(5px);
   width: 100%;
   height: 100%;
 }
@@ -14,21 +14,19 @@
   position: fixed;
   top: 50%;
   left: 50%;
+  transform: translate(-50%, -50%);
   width: 50%;
   @media (max-width: $tablet-max-width) {
     width: 60%;
   }
-
   min-height: 50%;
-
-  transform: translate(-50%, -50%);
   padding: 2rem;
   border-radius: 8px;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
   animation-name: spring-effect;
   animation-duration: 0.2s;
   will-change: transform;
-  background-color: $off-white;
+  background-color: $background;
 
   display: flex;
   flex-direction: column;
@@ -92,7 +90,7 @@
     }
   }
 
-  & > .spliter {
+  .spliter {
     width: 100%;
     border: 1px solid $placeholder;
   }

--- a/client/src/components/PaymentTypeAddModal/index.scss
+++ b/client/src/components/PaymentTypeAddModal/index.scss
@@ -1,0 +1,164 @@
+@import '../../global.scss';
+
+.blur-background {
+  position: fixed;
+  left: 0;
+  top: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(5px);
+  width: 100%;
+  height: 100%;
+}
+
+.payment-type-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 50%;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  background-color: $background;
+
+  & > * {
+    width: 100%;
+  }
+
+  &--title {
+    font-size: 2em;
+    padding-bottom: 1em;
+    color: $label;
+  }
+
+  &--name-section {
+    display: flex;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    &--label {
+      flex-basis: 4em;
+      flex-shrink: 0;
+      color: $label;
+      font-size: 1.5em;
+    }
+    &--input {
+      background-color: transparent;
+      flex-grow: 1;
+      outline: none;
+      border: none;
+      border-bottom: 1px solid $label;
+    }
+  }
+
+  &--bg-section {
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    display: flex;
+    &--label {
+      display: flex;
+      align-items: center;
+      flex-basis: 4em;
+      flex-shrink: 0;
+      color: $label;
+      font-size: 1.5em;
+    }
+    .bg-color-picker {
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-grow: 1;
+      &--item {
+        padding: 2px;
+        margin-right: 1rem;
+        border-radius: 4px;
+        .box {
+          border-radius: 4px;
+          width: 25px;
+          height: 25px;
+          background-color: turquoise;
+        }
+        &.select {
+          border: 1px solid $primary;
+        }
+      }
+    }
+  }
+
+  &--font-section {
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    display: flex;
+    &--label {
+      display: flex;
+      align-items: center;
+      flex-basis: 4em;
+      flex-shrink: 0;
+      color: $label;
+      font-size: 1.5em;
+    }
+    .font-color-picker {
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-grow: 1;
+      &--item {
+        padding: 2px;
+        margin-right: 1rem;
+        border-radius: 4px;
+        .box {
+          border-radius: 4px;
+          width: 25px;
+          height: 25px;
+          background-color: turquoise;
+        }
+        &.select {
+          border: 1px solid $primary;
+        }
+      }
+    }
+  }
+
+  &--preview-section {
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    &--label {
+      justify-self: flex-start;
+    }
+    .preview-card {
+      padding: 1rem;
+      width: 200px;
+      height: 100px;
+      color: white;
+      background-color: turquoise;
+      border-radius: 8px;
+    }
+  }
+
+  &--btn-container {
+    display: flex;
+    justify-content: space-between;
+    &--btn {
+      padding: 1em 2em;
+      border-radius: 8px;
+      border: 1px solid $primary;
+      background-color: transparent;
+      color: $primary;
+      &:hover {
+        color: $off-white;
+        background-color: $primary;
+      }
+
+      &:not(:first-child) {
+        margin-left: 1em;
+      }
+    }
+  }
+}

--- a/client/src/components/PaymentTypeAddModal/index.scss
+++ b/client/src/components/PaymentTypeAddModal/index.scss
@@ -49,6 +49,7 @@
     &--input {
       background-color: transparent;
       flex-grow: 1;
+      color: inherit;
       outline: none;
       border: none;
       border-bottom: 1px solid $label;

--- a/client/src/components/PaymentTypeAddModal/index.scss
+++ b/client/src/components/PaymentTypeAddModal/index.scss
@@ -67,26 +67,6 @@
       color: $label;
       font-size: 1.5em;
     }
-    .bg-color-picker {
-      padding: 0;
-      margin: 0;
-      display: flex;
-      flex-grow: 1;
-      &--item {
-        padding: 2px;
-        margin-right: 1rem;
-        border-radius: 4px;
-        .box {
-          border-radius: 4px;
-          width: 25px;
-          height: 25px;
-          background-color: turquoise;
-        }
-        &.select {
-          border: 1px solid $primary;
-        }
-      }
-    }
   }
 
   &--font-section {
@@ -101,24 +81,26 @@
       color: $label;
       font-size: 1.5em;
     }
-    .font-color-picker {
-      padding: 0;
-      margin: 0;
-      display: flex;
-      flex-grow: 1;
-      &--item {
-        padding: 2px;
-        margin-right: 1rem;
+  }
+
+  .color-picker {
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-grow: 1;
+    &--item {
+      padding: 2px;
+      margin-right: 1rem;
+      border-radius: 4px;
+      .box {
+        pointer-events: none;
         border-radius: 4px;
-        .box {
-          border-radius: 4px;
-          width: 25px;
-          height: 25px;
-          background-color: turquoise;
-        }
-        &.select {
-          border: 1px solid $primary;
-        }
+        width: 25px;
+        height: 25px;
+        background-color: turquoise;
+      }
+      &.select {
+        border: 1px solid $primary;
       }
     }
   }

--- a/client/src/components/PaymentTypeAddModal/index.ts
+++ b/client/src/components/PaymentTypeAddModal/index.ts
@@ -1,0 +1,102 @@
+import './index.scss';
+
+import Component from '@/src/core/Component';
+import { html } from '@/src/utils/codeHelper';
+import { qs } from '@/src/utils/selecthelper';
+
+interface IState {}
+
+interface IProps {}
+
+export default class PaymentTypeAddModal extends Component<IState, IProps> {
+  template() {
+    return html`
+      <div class="blur-background"></div>
+      <div class="payment-type-modal">
+        <div class="payment-type-modal--title">결제 수단 추가</div>
+        <div class="payment-type-modal--name-section">
+          <label class="payment-type-modal--name-section--label" for="name-input"> 이름 </label>
+          <input
+            id="name-input"
+            class="payment-type-modal--name-section--input"
+            placeholder="결제 수단의 이름을 입력해주세요."
+          />
+        </div>
+        <div class="payment-type-modal--bg-section">
+          <div class="payment-type-modal--bg-section--label">배경색</div>
+          <ul class="bg-color-picker">
+            <li class="bg-color-picker--item">
+              <div class="box"></div>
+            </li>
+            <li class="bg-color-picker--item select">
+              <div class="box"></div>
+            </li>
+            <li class="bg-color-picker--item">
+              <div class="box"></div>
+            </li>
+            <li class="bg-color-picker--item">
+              <div class="box"></div>
+            </li>
+          </ul>
+        </div>
+        <div class="payment-type-modal--font-section">
+          <div class="payment-type-modal--font-section--label">글자색</div>
+          <ul class="font-color-picker">
+            <li class="font-color-picker--item select">
+              <div class="box"></div>
+            </li>
+            <li class="font-color-picker--item">
+              <div class="box"></div>
+            </li>
+            <li class="font-color-picker--item">
+              <div class="box"></div>
+            </li>
+            <li class="font-color-picker--item">
+              <div class="box"></div>
+            </li>
+          </ul>
+        </div>
+        <div class="payment-type-modal--preview-section">
+          <div class="payment-type-modal--preview-section--label">Preview</div>
+          <div class="preview-card">임시 테스트 카드입니다.</div>
+        </div>
+        <div class="payment-type-modal--btn-container">
+          <div id="cancel-btn" class="payment-type-modal--btn-container--btn">취소</div>
+          <div id="submit-btn" class="payment-type-modal--btn-container--btn">생성</div>
+        </div>
+      </div>
+    `;
+  }
+
+  mounted() {
+    this.bindingEvents();
+  }
+
+  bindingEvents() {
+    const $cancelBtn = qs('#cancel-btn', this.$target) as HTMLElement;
+    $cancelBtn.addEventListener('click', () => {
+      // TODO: data clear
+
+      this.hide();
+    });
+
+    const $submitBtn = qs('#submit-btn', this.$target) as HTMLElement;
+    $submitBtn.addEventListener('click', () => {
+      // TODO: data clear
+      this.hide();
+    });
+
+    const $blurBackgroundElement = qs('.blur-background', this.$target) as HTMLElement;
+    $blurBackgroundElement.addEventListener('click', () => {
+      this.hide();
+    });
+  }
+
+  show() {
+    this.$target.style.display = 'block';
+  }
+
+  hide() {
+    this.$target.style.display = 'none';
+  }
+}

--- a/client/src/components/PaymentTypeAddModal/index.ts
+++ b/client/src/components/PaymentTypeAddModal/index.ts
@@ -2,13 +2,39 @@ import './index.scss';
 
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
-import { qs } from '@/src/utils/selecthelper';
+import { qs, qsAll } from '@/src/utils/selecthelper';
 
-interface IState {}
+const backgroundColors = [
+  '#6ed5eb',
+  '#4cb8b8',
+  '#94d3cc',
+  '#4ca1de',
+  '#d092e2',
+  '#817dce',
+  '#4a6cc3',
+  '#b9d58c',
+  '#e6d267',
+  '#e2b765',
+];
+
+const fontColors = ['#ffffff', '#000000'];
+
+interface IState {
+  bgColor: string;
+  fontColor: string;
+  name: string;
+}
 
 interface IProps {}
 
 export default class PaymentTypeAddModal extends Component<IState, IProps> {
+  setup() {
+    this.$state = {
+      bgColor: '',
+      fontColor: '',
+      name: '',
+    };
+  }
   template() {
     return html`
       <div class="blur-background"></div>
@@ -24,41 +50,35 @@ export default class PaymentTypeAddModal extends Component<IState, IProps> {
         </div>
         <div class="payment-type-modal--bg-section">
           <div class="payment-type-modal--bg-section--label">배경색</div>
-          <ul class="bg-color-picker">
-            <li class="bg-color-picker--item">
-              <div class="box"></div>
-            </li>
-            <li class="bg-color-picker--item select">
-              <div class="box"></div>
-            </li>
-            <li class="bg-color-picker--item">
-              <div class="box"></div>
-            </li>
-            <li class="bg-color-picker--item">
-              <div class="box"></div>
-            </li>
+          <ul id="bg-color-picker" class="color-picker">
+            ${backgroundColors
+              .map(
+                color => html`
+                  <li class="color-picker--item" data-color="${color}">
+                    <div class="box" style="background-color:${color}"></div>
+                  </li>
+                `
+              )
+              .join('')}
           </ul>
         </div>
         <div class="payment-type-modal--font-section">
           <div class="payment-type-modal--font-section--label">글자색</div>
-          <ul class="font-color-picker">
-            <li class="font-color-picker--item select">
-              <div class="box"></div>
-            </li>
-            <li class="font-color-picker--item">
-              <div class="box"></div>
-            </li>
-            <li class="font-color-picker--item">
-              <div class="box"></div>
-            </li>
-            <li class="font-color-picker--item">
-              <div class="box"></div>
-            </li>
+          <ul id="font-color-picker" class="color-picker">
+            ${fontColors
+              .map(
+                color => html`
+                  <li class="color-picker--item" data-color="${color}">
+                    <div class="box" style="background-color:${color}"></div>
+                  </li>
+                `
+              )
+              .join('')}
           </ul>
         </div>
         <div class="payment-type-modal--preview-section">
           <div class="payment-type-modal--preview-section--label">Preview</div>
-          <div class="preview-card">임시 테스트 카드입니다.</div>
+          <div class="preview-card"></div>
         </div>
         <div class="payment-type-modal--btn-container">
           <div id="cancel-btn" class="payment-type-modal--btn-container--btn">취소</div>
@@ -75,21 +95,85 @@ export default class PaymentTypeAddModal extends Component<IState, IProps> {
   bindingEvents() {
     const $cancelBtn = qs('#cancel-btn', this.$target) as HTMLElement;
     $cancelBtn.addEventListener('click', () => {
-      // TODO: data clear
-
+      this.clear();
       this.hide();
     });
 
     const $submitBtn = qs('#submit-btn', this.$target) as HTMLElement;
     $submitBtn.addEventListener('click', () => {
-      // TODO: data clear
+      this.submit();
+      this.clear();
       this.hide();
     });
 
     const $blurBackgroundElement = qs('.blur-background', this.$target) as HTMLElement;
     $blurBackgroundElement.addEventListener('click', () => {
+      this.clear();
       this.hide();
     });
+
+    const $bgColorPicker = qs('#bg-color-picker', this.$target) as HTMLElement;
+    $bgColorPicker.addEventListener('click', e => this.handleColorPickerClickEvent(e, this.updateBgColor.bind(this)));
+
+    const $fontColorPicker = qs('#font-color-picker', this.$target) as HTMLElement;
+    $fontColorPicker.addEventListener('click', e =>
+      this.handleColorPickerClickEvent(e, this.updateFontColor.bind(this))
+    );
+
+    const $nameInput = qs('#name-input', this.$target) as HTMLElement;
+    $nameInput.addEventListener('input', e => this.handleChangeNameInputEvent(e));
+  }
+
+  handleColorPickerClickEvent(e: MouseEvent, cb: (color: string) => void) {
+    const currentTarget = e.currentTarget as HTMLElement;
+    const target = e.target as HTMLElement;
+
+    const colorItems = qsAll('.color-picker--item', currentTarget);
+    for (const colorItem of colorItems) {
+      if (target === colorItem) {
+        const { color } = target.dataset;
+        if (typeof color === 'string') {
+          cb(color);
+        }
+      }
+    }
+  }
+
+  handleChangeNameInputEvent(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.$state.name = target.value;
+    this.renderPreviewCard();
+  }
+
+  updateBgColor(color: string) {
+    this.$state.bgColor = color;
+    this.renderPreviewCard();
+  }
+
+  updateFontColor(color: string) {
+    this.$state.fontColor = color;
+    this.renderPreviewCard();
+  }
+
+  renderPreviewCard() {
+    const $previewCardElement = qs('.preview-card', this.$target) as HTMLElement;
+    const { fontColor, bgColor, name } = this.$state;
+
+    $previewCardElement.style.color = fontColor;
+    $previewCardElement.style.backgroundColor = bgColor;
+    $previewCardElement.innerText = name;
+  }
+
+  submit() {
+    //TODO: 검증 후 카드 생성
+  }
+
+  clear() {
+    this.$state = {
+      bgColor: '',
+      fontColor: '',
+      name: '',
+    };
   }
 
   show() {

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -16,11 +16,15 @@
   padding: 35px;
   margin: 0 auto;
   border-radius: 8px;
-  background-color: white;
+  background-color: $background;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 .chart-container {
+  @media (max-width: $tablet-max-width) {
+    width: 300px;
+    height: 300px;
+  }
   width: 400px;
   height: 400px;
 }

--- a/client/src/pages/WalletPage/index.scss
+++ b/client/src/pages/WalletPage/index.scss
@@ -50,6 +50,10 @@
     position: relative;
     flex-shrink: 0;
     padding: 1em;
+    @media (max-width: $phone-max-width) {
+      height: 200px;
+      width: 100px;
+    }
     height: 200px;
     width: 150px;
     border-radius: 16px;

--- a/client/src/pages/WalletPage/index.scss
+++ b/client/src/pages/WalletPage/index.scss
@@ -1,1 +1,107 @@
 @import '../../global.scss';
+
+.wallet-container {
+  position: relative;
+  top: -30px;
+  align-items: center;
+  height: 500px;
+  width: 80%;
+  margin: 0 auto;
+
+  padding: 35px;
+  border-radius: 8px;
+
+  background-color: $background;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.wallet-edit-container {
+  display: flex;
+  justify-content: flex-start;
+
+  &--btn {
+    padding: 1em 2em;
+    border-radius: 8px;
+    border: 1px solid $primary;
+    background-color: transparent;
+    color: $primary;
+    &:hover {
+      color: $off-white;
+      background-color: $primary;
+    }
+
+    &:not(:first-child) {
+      margin-left: 1em;
+    }
+
+    &.editmode {
+      color: $off-white;
+      background-color: $primary;
+    }
+  }
+}
+
+.card-list {
+  padding: 0;
+  display: flex;
+  padding: 2em;
+  overflow-x: scroll;
+  &--item {
+    position: relative;
+    flex-shrink: 0;
+    padding: 1em;
+    height: 200px;
+    width: 150px;
+    border-radius: 16px;
+    box-shadow: -1rem 0 0.2rem rgba(0, 0, 0, 0.5);
+    background-color: white;
+    transition: 0.2s;
+    &--name {
+      color: black;
+    }
+    &:hover {
+      transform: translateY(-1rem);
+    }
+    &:hover ~ & {
+      transform: translateX(30px);
+    }
+    &:not(:first-child) {
+      margin-left: -30px;
+    }
+
+    &.editmode {
+      &:not(:first-child) {
+        margin-left: 30px;
+      }
+      &:hover {
+        transform: translateY(0rem);
+      }
+      &:hover ~ & {
+        transform: translateX(0px);
+      }
+    }
+
+    &--delete-btn {
+      position: absolute;
+      right: -1em;
+      top: -1em;
+      width: 2em;
+      height: 2em;
+      border-radius: 100%;
+      background-color: $primary;
+      color: $off-white;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: 0.2s;
+      &:hover {
+        transform: scale(1.2);
+      }
+    }
+
+    &.editmode > &--delete-btn {
+      display: flex;
+    }
+  }
+}

--- a/client/src/pages/WalletPage/index.scss
+++ b/client/src/pages/WalletPage/index.scss
@@ -109,3 +109,7 @@
     }
   }
 }
+
+#payment-type-modal {
+  display: none;
+}

--- a/client/src/pages/WalletPage/index.ts
+++ b/client/src/pages/WalletPage/index.ts
@@ -1,19 +1,26 @@
 import './index.scss';
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
+import { qs, qsAll } from '@/src/utils/selecthelper';
 import { getPaymentTypesAsync, PaymentType } from '@/src/api/paymentTypeAPI';
 
 interface IState {
   paymentTypes: PaymentType[];
+  isEditMode?: boolean;
+  $editButton?: HTMLElement;
 }
 
 interface IProps {}
+
+const EDIT_MODE_ON_STRING = '수정 하기';
+const EDIT_MODE_OFF_STRING = '수정 중';
 
 export default class WalletPage extends Component<IState, IProps> {
   setup() {
     getPaymentTypesAsync().then(({ success, data }) => {
       this.setState({
         paymentTypes: data,
+        isEditMode: false,
       });
     });
   }
@@ -27,7 +34,7 @@ export default class WalletPage extends Component<IState, IProps> {
 
         <div class="wallet-edit-container">
           <div class="wallet-edit-container--btn">추가</div>
-          <div class="wallet-edit-container--btn">수정</div>
+          <div id="edit-mode-toggle-btn" class="wallet-edit-container--btn">${EDIT_MODE_ON_STRING}</div>
         </div>
 
         <ul class="card-list">
@@ -35,7 +42,7 @@ export default class WalletPage extends Component<IState, IProps> {
           paymentTypes
             .map(
               paymentType =>
-                html`<li class="card-list--item edit" style="background-color:${paymentType.bgColor}">
+                html`<li class="card-list--item" style="background-color:${paymentType.bgColor}">
                   <div class="card-list--item--name" style="color:${paymentType.fontColor}">${paymentType.name}</div>
                   <span class="card-list--item--delete-btn">X</span>
                 </li>`
@@ -46,5 +53,43 @@ export default class WalletPage extends Component<IState, IProps> {
     `;
   }
 
-  mounted() {}
+  mounted() {
+    this.$state.$editButton = qs('#edit-mode-toggle-btn', this.$target) as HTMLElement;
+    this.$state.$editButton.addEventListener('click', e => {
+      this.toggleEditMode();
+    });
+  }
+
+  toggleEditMode() {
+    const { isEditMode, $editButton } = this.$state;
+    if (isEditMode) {
+      if ($editButton) {
+        $editButton.innerText = EDIT_MODE_OFF_STRING;
+        $editButton.classList.add('editmode');
+        this.changeAllCardsAsEditMode();
+      }
+      this.$state.isEditMode = false;
+    } else {
+      if ($editButton) {
+        $editButton.innerText = EDIT_MODE_ON_STRING;
+        $editButton.classList.remove('editmode');
+        this.changeAllCardsAsReadMode();
+      }
+      this.$state.isEditMode = true;
+    }
+  }
+
+  changeAllCardsAsEditMode() {
+    const cardElements = qsAll('.card-list--item', this.$target);
+    for (const $cardElement of cardElements) {
+      $cardElement.classList.add('editmode');
+    }
+  }
+
+  changeAllCardsAsReadMode() {
+    const cardElements = qsAll('.card-list--item', this.$target);
+    for (const $cardElement of cardElements) {
+      $cardElement.classList.remove('editmode');
+    }
+  }
 }

--- a/client/src/pages/WalletPage/index.ts
+++ b/client/src/pages/WalletPage/index.ts
@@ -3,6 +3,7 @@ import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
 import { qs, qsAll } from '@/src/utils/selecthelper';
 import { getPaymentTypesAsync, PaymentType } from '@/src/api/paymentTypeAPI';
+import PaymentTypeAddModal from '@/src/components/PaymentTypeAddModal';
 
 interface IState {
   paymentTypes: PaymentType[];
@@ -16,48 +17,71 @@ const EDIT_MODE_ON_STRING = '수정 하기';
 const EDIT_MODE_OFF_STRING = '수정 중';
 
 export default class WalletPage extends Component<IState, IProps> {
-  setup() {
-    getPaymentTypesAsync().then(({ success, data }) => {
-      this.setState({
-        paymentTypes: data,
-        isEditMode: false,
-      });
-    });
-  }
-
   template() {
     const { paymentTypes } = this.$state;
     return html`
       <div class="wallet-container">
         <h1>My Wallet</h1>
         <hr />
-
         <div class="wallet-edit-container">
-          <div class="wallet-edit-container--btn">추가</div>
+          <div id="add-payment-btn" class="wallet-edit-container--btn">추가</div>
           <div id="edit-mode-toggle-btn" class="wallet-edit-container--btn">${EDIT_MODE_ON_STRING}</div>
         </div>
-
-        <ul class="card-list">
-          ${paymentTypes &&
-          paymentTypes
-            .map(
-              paymentType =>
-                html`<li class="card-list--item" style="background-color:${paymentType.bgColor}">
-                  <div class="card-list--item--name" style="color:${paymentType.fontColor}">${paymentType.name}</div>
-                  <span class="card-list--item--delete-btn">X</span>
-                </li>`
-            )
-            .join('')}
-        </ul>
+        <ul class="card-list"></ul>
       </div>
+      <div id="payment-type-modal"></div>
     `;
+  }
+
+  setup() {
+    getPaymentTypesAsync().then(({ success, data }) => {
+      if (success) {
+        this.$state.paymentTypes = data;
+        this.renderCardItems();
+      } else {
+        throw new Error('Payment Types Fetching Fail.');
+      }
+    });
+  }
+
+  renderCardItems() {
+    const $cardListElement = qs('.card-list', this.$target) as HTMLElement;
+    const { paymentTypes } = this.$state;
+
+    $cardListElement.innerHTML = paymentTypes
+      .map(
+        paymentType =>
+          html`<li class="card-list--item" style="background-color:${paymentType.bgColor}">
+            <div class="card-list--item--name" style="color:${paymentType.fontColor}">${paymentType.name}</div>
+            <span class="card-list--item--delete-btn">X</span>
+          </li>`
+      )
+      .join('');
   }
 
   mounted() {
     this.$state.$editButton = qs('#edit-mode-toggle-btn', this.$target) as HTMLElement;
-    this.$state.$editButton.addEventListener('click', e => {
-      this.toggleEditMode();
+
+    const $paymentTypeAddModal = qs('#payment-type-modal', this.$target) as HTMLElement;
+    const paymentAddModal = new PaymentTypeAddModal($paymentTypeAddModal);
+
+    const $addPaymentTypeButton = qs('#add-payment-btn', this.$target) as HTMLElement;
+
+    $addPaymentTypeButton.addEventListener('click', () => {
+      paymentAddModal.show();
     });
+
+    this.bindingEvents();
+  }
+
+  bindingEvents() {
+    if (this.$state.$editButton) {
+      this.$state.$editButton.addEventListener('click', e => {
+        this.toggleEditMode();
+      });
+    } else {
+      throw new Error('Edit Button Binding Fail');
+    }
   }
 
   toggleEditMode() {

--- a/client/src/pages/WalletPage/index.ts
+++ b/client/src/pages/WalletPage/index.ts
@@ -1,14 +1,50 @@
-import Component from '@/src/core/Component';
 import './index.scss';
+import Component from '@/src/core/Component';
+import { html } from '@/src/utils/codeHelper';
+import { getPaymentTypesAsync, PaymentType } from '@/src/api/paymentTypeAPI';
 
-interface IState {}
+interface IState {
+  paymentTypes: PaymentType[];
+}
 
 interface IProps {}
 
 export default class WalletPage extends Component<IState, IProps> {
+  setup() {
+    getPaymentTypesAsync().then(({ success, data }) => {
+      this.setState({
+        paymentTypes: data,
+      });
+    });
+  }
+
   template() {
-    return `
-        <h1>Your Wallet</h1>
+    const { paymentTypes } = this.$state;
+    return html`
+      <div class="wallet-container">
+        <h1>My Wallet</h1>
+        <hr />
+
+        <div class="wallet-edit-container">
+          <div class="wallet-edit-container--btn">추가</div>
+          <div class="wallet-edit-container--btn">수정</div>
+        </div>
+
+        <ul class="card-list">
+          ${paymentTypes &&
+          paymentTypes
+            .map(
+              paymentType =>
+                html`<li class="card-list--item edit" style="background-color:${paymentType.bgColor}">
+                  <div class="card-list--item--name" style="color:${paymentType.fontColor}">${paymentType.name}</div>
+                  <span class="card-list--item--delete-btn">X</span>
+                </li>`
+            )
+            .join('')}
+        </ul>
+      </div>
     `;
   }
+
+  mounted() {}
 }


### PR DESCRIPTION
#35 

## 개요

결제 수단을 추가할 수 있는 기능이 필요해서 메인에서 모달을 추가하기 보다는 새로운 페이지를 추가했습니다.

## 변경사항

- Wallet Page에서 카드를 추가할 수 있는 `PaymentTypeAddModal` 모달을 추가했습니다.

해당 모달은 카드의 색과 글자색을 사용자가 직접 수정할 수 있습니다.

## 참고사항

- 카드 삭제를 눌렀을 때 어떻게 처리할지에 대한 구상과 리렌더링 방식을 고민해봐야합니다.

## 추가 구현 필요사항



## 스크린샷

<img width="880" alt="스크린샷 2021-07-29 오후 10 49 07" src="https://user-images.githubusercontent.com/20085849/127503697-84d7713c-f872-40e2-b9b6-126d6d14a76d.png">

<img width="1158" alt="스크린샷 2021-07-29 오후 10 48 44" src="https://user-images.githubusercontent.com/20085849/127503729-5c410500-4bc3-4b7f-a8f3-59fa14c893c9.png">

