### PR TITLE
fix: color picker overflow 수정(flex-wrap)

### DIFF
--- a/client/src/components/PaymentTypeAddModal/index.scss
+++ b/client/src/components/PaymentTypeAddModal/index.scss
@@ -15,7 +15,8 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 50%;
+  width: 80%;
+  max-width: 500px;
   padding: 2rem;
   border-radius: 8px;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
@@ -88,11 +89,13 @@
     padding: 0;
     margin: 0;
     display: flex;
+    flex-wrap: wrap;
     flex-grow: 1;
     &--item {
       padding: 2px;
       margin-right: 1rem;
       border-radius: 4px;
+      border: 1px solid transparent;
       .box {
         pointer-events: none;
         border-radius: 4px;
@@ -101,7 +104,7 @@
         background-color: turquoise;
       }
       &.select {
-        border: 1px solid $primary;
+        border: 1px solid red;
       }
     }
   }

--- a/client/src/components/PaymentTypeAddModal/index.ts
+++ b/client/src/components/PaymentTypeAddModal/index.ts
@@ -128,13 +128,21 @@ export default class PaymentTypeAddModal extends Component<IState, IProps> {
     const currentTarget = e.currentTarget as HTMLElement;
     const target = e.target as HTMLElement;
 
+    const pickers = qsAll('.color-picker', this.$target);
+    for (const picker of pickers) {
+      if (picker === target) return;
+    }
+
     const colorItems = qsAll('.color-picker--item', currentTarget);
     for (const colorItem of colorItems) {
       if (target === colorItem) {
         const { color } = target.dataset;
+        colorItem.classList.add('select');
         if (typeof color === 'string') {
           cb(color);
         }
+      } else {
+        colorItem.classList.remove('select');
       }
     }
   }


### PR DESCRIPTION
#35 

## 개요

카드 입력 화면에서 Picker 의 Color 아이템들이 OverFlow 되는 버그와

item이 아닌 Picker를 눌렀을 때 Select 표시가 해제되는 버그 해결

## 스크린샷

<img width="621" alt="스크린샷 2021-07-29 오후 11 56 29" src="https://user-images.githubusercontent.com/20085849/127515086-70c0212a-0281-405e-bec8-dc3a7074e0df.png">
