### PR TITLE
LineChart 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1600,6 +1600,12 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -2274,6 +2280,12 @@
         "to-regex": "^3.0.1"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserslist": {
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
@@ -2405,7 +2417,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
       "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -2422,7 +2433,6 @@
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
           "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
@@ -2432,15 +2442,13 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
           "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "fill-range": "^7.0.1"
           }
@@ -2450,7 +2458,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "to-regex-range": "^5.0.1"
           }
@@ -2460,7 +2467,6 @@
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
           "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "binary-extensions": "^2.0.0"
           }
@@ -2469,15 +2475,13 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "readdirp": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
           "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "picomatch": "^2.2.1"
           }
@@ -2487,7 +2491,6 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-number": "^7.0.0"
           }
@@ -4279,6 +4282,12 @@
         "path-exists": "^4.0.0"
       }
     },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -4555,6 +4564,12 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "handle-thing": {
@@ -5216,6 +5231,12 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -5526,6 +5547,67 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "loglevel": {
       "version": "1.7.1",
@@ -5856,6 +5938,239 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
+    },
+    "mocha": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
+      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.2",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.7",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.23",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.5",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
+        }
+      }
     },
     "ms": {
       "version": "2.1.2",
@@ -9491,6 +9806,12 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "workerpool": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -9670,6 +9991,38 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        }
+      }
     },
     "yn": {
       "version": "3.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "html-loader": "^2.1.2",
     "html-webpack-plugin": "^5.3.2",
     "mini-css-extract-plugin": "^2.1.0",
+    "mocha": "^9.0.3",
     "node-sass": "^6.0.1",
     "optimize-css-assets-webpack-plugin": "^6.0.1",
     "sass-loader": "^12.1.0",

--- a/client/src/interfaces/Ledger.ts
+++ b/client/src/interfaces/Ledger.ts
@@ -14,3 +14,7 @@ export interface ILedgerList {
   spand: number; //총지출
   ledgers: ILedger[];
 }
+
+export interface IStatisticLedgerByDate {}
+
+export interface IStatisticLedgerByCategory {}

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -4,13 +4,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-
-  width: 600px;
-  @media (max-width: $tablet-max-width) {
-    flex-wrap: wrap;
-    width: 400px;
-  }
-
+  align-items: center;
   padding: 35px;
   margin: 0 auto;
   border-radius: 8px;
@@ -20,50 +14,68 @@
 
 .chart-container {
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
+  align-items: center;
   border: 1px solid $primary;
-}
-
-#pie-chart {
-  width: 300px;
+  width: 70%;
   height: 400px;
-}
-
-.category-container {
-  flex-grow: 1;
-  align-self: flex-start;
-
-  &--title {
-    font-size: 22px;
+  @media (max-width: $tablet-max-width) {
+    flex-wrap: wrap;
+    width: 90%;
   }
 
-  &--list {
-    padding: 0px;
-    margin-top: 35px;
-    &--item {
-      display: flex;
-      padding-bottom: 20px;
-      padding-top: 20px;
-      border-bottom: 1px solid $label;
-      & > .category {
-        flex-grow: 1;
+  #pie-chart {
+    flex-shrink: 0;
+    width: 300px;
+    height: 300px;
+  }
+
+  .category-container {
+    align-self: flex-start;
+
+    &--title {
+      font-size: 22px;
+    }
+
+    &--list {
+      padding: 0px;
+      margin-top: 35px;
+      &--item {
         display: flex;
-        justify-self: center;
-        & > span {
-          width: 80%;
+        padding-bottom: 20px;
+        padding-top: 20px;
+        border-bottom: 1px solid $label;
+        & > .category {
+          flex-grow: 1;
+          display: flex;
+          justify-self: center;
+          & > span {
+            width: 80%;
+          }
         }
-      }
-      & > .percent {
-        flex-grow: 1;
-      }
-      & > .cost {
-        text-align: end;
-        flex-grow: 1;
+        & > .percent {
+          flex-grow: 1;
+        }
+        & > .cost {
+          text-align: end;
+          flex-grow: 1;
+        }
       }
     }
   }
 }
 
 .sub-chart-container {
+  display: flex;
+  justify-content: center;
   border: 1px solid $primary;
+  width: 70%;
+  #line-chart {
+    width: 800px;
+    height: 500px;
+    @media (max-width: $tablet-max-width) {
+      width: 400px;
+      height: 250px;
+    }
+  }
 }

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -69,8 +69,8 @@
   justify-content: center;
 
   #line-chart {
-    width: 800px;
-    height: 500px;
+    width: 600px;
+    height: 375px;
     @media (max-width: $tablet-max-width) {
       width: 400px;
       height: 250px;

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -2,10 +2,8 @@
 
 .statistic-container {
   position: relative;
-  top: -30px;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
 
   width: 600px;
   @media (max-width: $tablet-max-width) {
@@ -21,18 +19,20 @@
 }
 
 .chart-container {
-  @media (max-width: $tablet-max-width) {
-    width: 300px;
-    height: 300px;
-  }
-  width: 400px;
+  display: flex;
+  justify-content: flex-start;
+  border: 1px solid $primary;
+}
+
+#pie-chart {
+  width: 300px;
   height: 400px;
 }
 
 .category-container {
   flex-grow: 1;
   align-self: flex-start;
-  height: 500px;
+
   &--title {
     font-size: 22px;
   }
@@ -62,4 +62,8 @@
       }
     }
   }
+}
+
+.sub-chart-container {
+  border: 1px solid $primary;
 }

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -7,6 +7,7 @@
   align-items: center;
   padding: 35px;
   margin: 0 auto;
+  width: 80%;
   border-radius: 8px;
   background-color: $background;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
@@ -16,8 +17,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 1px solid $primary;
-  width: 70%;
   height: 400px;
   @media (max-width: $tablet-max-width) {
     flex-wrap: wrap;
@@ -68,8 +67,7 @@
 .sub-chart-container {
   display: flex;
   justify-content: center;
-  border: 1px solid $primary;
-  width: 70%;
+
   #line-chart {
     width: 800px;
     height: 500px;

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -1,10 +1,11 @@
 import Component from '@/src/core/Component';
+import { LineChart, LineChartData } from '@/src/utils/charts/LineChart';
 import PieChart, { PiChartData } from '@/src/utils/PieChart';
 
 import './index.scss';
 
 // TODO: Mocking Data
-const mockData: PiChartData[] = [
+const mockDataByCategory: PiChartData[] = [
   { name: '카드', value: 10, color: 'Coral' },
   { name: '현금', value: 50, color: '#00ab6b' },
   { name: '적금', value: 30, color: '#00ab6b' },
@@ -12,62 +13,93 @@ const mockData: PiChartData[] = [
   { name: '적금', value: 30, color: '#00ab6b' },
 ];
 
+const mockDataByDate: LineChartData[] = [
+  {
+    name: 'A',
+    datetime: new Date('2021-07-21'),
+    value: 10,
+  },
+  {
+    name: 'B',
+    datetime: new Date('2021-07-22'),
+
+    value: 30,
+  },
+  {
+    name: 'C',
+    datetime: new Date('2021-07-24'),
+
+    value: 50,
+  },
+  {
+    name: 'D',
+    datetime: new Date('2021-07-27'),
+    value: 20,
+  },
+];
+
 interface IState {
-  data?: PiChartData[];
+  dataByCategory?: PiChartData[];
+  dataByDate?: LineChartData[];
 }
 interface IProps {}
 
 export default class StatisticPage extends Component<IState, IProps> {
   template() {
-    const { data } = this.$state;
-
     return /* html */ `
             <div class='statistic-container'>
-                <svg id="piechart" class="chart-container"></svg>
+              <div class="chart-container">
+                <svg id="pie-chart"></svg>
                 <div class="category-container">
                   <h1 class="category-container--title">이번 달 지출 금액 843,000 </h1>
-                  <ul class="category-container--list">
-                  
-                  ${
-                    data &&
-                    data
-                      .map(
-                        (d: any) => /*html */ `
-                    <li class="category-container--list--item">
-                        <div class="category" >
-                          <span class="ledger-category" data-category-type="2"> ${d.name}</span>
-                        </div>
-                        <div class="percent">${d.value}%</div>
-                        <div class="cost">${d.value}</div>
-                    </li>`
-                      )
-                      .join('')
-                  }
-                  </ul>
                 </div>
+              </div>
+              <div class="sub-chart-container">
+                <svg id="line-chart"></svg>
+              </div>
             </div>
           `;
   }
 
   setup() {
-    this.$state = { data: [] };
-    // TODO: Change Real API
+    this.$state = { dataByCategory: [], dataByDate: [] };
     setTimeout(() => {
       this.setState({
-        data: mockData,
+        dataByCategory: mockDataByCategory,
+        dataByDate: mockDataByDate,
       });
     }, 300);
   }
 
   mounted() {
-    const $pieChart = document.querySelector('#piechart') as HTMLElement;
-    const { data } = this.$state;
+    const $pieChart = document.querySelector('#pie-chart') as SVGElement;
+    const { dataByCategory, dataByDate } = this.$state;
 
-    new PieChart($pieChart, data, {
+    PieChart.init($pieChart, dataByCategory, {
       onClick: (d: string) => {
         console.log('click: ' + d);
       },
-      radius: 100,
     });
+
+    const $lineChart = document.querySelector('#line-chart') as SVGElement;
+    LineChart.init($lineChart, dataByDate);
   }
 }
+
+// <ul class="category-container--list">
+//   ${
+//     data &&
+//     data
+//       .map(
+//         (d: any) => /*html */ `
+//     <li class="category-container--list--item">
+//         <div class="category" >
+//           <span class="ledger-category" data-category-type="2"> ${d.name}</span>
+//         </div>
+//         <div class="percent">${d.value}%</div>
+//         <div class="cost">${d.value}</div>
+//     </li>`
+//       )
+//       .join('')
+//   }
+// </ul>

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -27,23 +27,23 @@ const mockDataByDate: LineChartData[] = [
   },
   {
     name: 'C',
-    datetime: new Date('2021-07-24'),
+    datetime: new Date('2021-07-23'),
 
     value: 50,
   },
   {
     name: 'D',
-    datetime: new Date('2021-07-25'),
+    datetime: new Date('2021-07-24'),
     value: 40,
   },
   {
     name: 'D',
-    datetime: new Date('2021-07-27'),
+    datetime: new Date('2021-07-25'),
     value: 50,
   },
   {
     name: 'D',
-    datetime: new Date('2021-07-28'),
+    datetime: new Date('2021-07-26'),
     value: 5,
   },
 ];
@@ -97,21 +97,3 @@ export default class StatisticPage extends Component<IState, IProps> {
     }
   }
 }
-
-// <ul class="category-container--list">
-//   ${
-//     data &&
-//     data
-//       .map(
-//         (d: any) => /*html */ `
-//     <li class="category-container--list--item">
-//         <div class="category" >
-//           <span class="ledger-category" data-category-type="2"> ${d.name}</span>
-//         </div>
-//         <div class="percent">${d.value}%</div>
-//         <div class="cost">${d.value}</div>
-//     </li>`
-//       )
-//       .join('')
-//   }
-// </ul>

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -1,11 +1,11 @@
 import Component from '@/src/core/Component';
 import { LineChart, LineChartData } from '@/src/utils/charts/LineChart';
-import PieChart, { PiChartData } from '@/src/utils/PieChart';
+import PieChart, { PieChartData } from '@/src/utils/charts/PieChart';
 
 import './index.scss';
 
 // TODO: Mocking Data
-const mockDataByCategory: PiChartData[] = [
+const mockDataByCategory: PieChartData[] = [
   { name: '카드', value: 10, color: 'Coral' },
   { name: '현금', value: 50, color: '#00ab6b' },
   { name: '적금', value: 30, color: '#00ab6b' },
@@ -49,7 +49,7 @@ const mockDataByDate: LineChartData[] = [
 ];
 
 interface IState {
-  dataByCategory?: PiChartData[];
+  dataByCategory?: PieChartData[];
   dataByDate?: LineChartData[];
 }
 interface IProps {}

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -33,18 +33,18 @@ const mockDataByDate: LineChartData[] = [
   },
   {
     name: 'D',
-    datetime: new Date('2021-07-27'),
-    value: 20,
+    datetime: new Date('2021-07-25'),
+    value: 40,
   },
   {
     name: 'D',
     datetime: new Date('2021-07-27'),
-    value: 20,
+    value: 50,
   },
   {
     name: 'D',
-    datetime: new Date('2021-07-27'),
-    value: 20,
+    datetime: new Date('2021-07-28'),
+    value: 5,
   },
 ];
 
@@ -91,8 +91,10 @@ export default class StatisticPage extends Component<IState, IProps> {
       },
     });
 
-    const $lineChart = document.querySelector('#line-chart') as SVGElement;
-    LineChart.init($lineChart, dataByDate);
+    if (this.$state.dataByDate && this.$state.dataByDate.length > 0) {
+      const $lineChart = document.querySelector('#line-chart') as SVGElement;
+      LineChart.init($lineChart, dataByDate);
+    }
   }
 }
 

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -36,6 +36,16 @@ const mockDataByDate: LineChartData[] = [
     datetime: new Date('2021-07-27'),
     value: 20,
   },
+  {
+    name: 'D',
+    datetime: new Date('2021-07-27'),
+    value: 20,
+  },
+  {
+    name: 'D',
+    datetime: new Date('2021-07-27'),
+    value: 20,
+  },
 ];
 
 interface IState {

--- a/client/src/utils/PieChart.ts
+++ b/client/src/utils/PieChart.ts
@@ -20,10 +20,10 @@ export interface PiChartData {
 
 export default class PieChart {
   public settings: PiChartOption = {};
-  public element: HTMLElement;
+  public element: SVGElement;
   public data: PiChartData[];
 
-  constructor(element: HTMLElement, data: PiChartData[] = [], settings: PiChartOption = {}) {
+  constructor(element: SVGElement, data: PiChartData[], settings: PiChartOption = {}) {
     if (!(element instanceof Node)) {
       throw "Can't initialize PieChart because " + element + ' is not a Node.';
     }
@@ -149,5 +149,9 @@ export default class PieChart {
     const x = Math.cos(2 * Math.PI * percent);
     const y = Math.sin(2 * Math.PI * percent);
     return [x, y];
+  }
+
+  static init(element: SVGElement, data: PiChartData[] = [], options: PiChartOption = {}) {
+    new PieChart(element, data);
   }
 }

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -1,5 +1,5 @@
 import { transformer, ScaleFn } from './scale';
-import { svgGroup, svgLine, svgText, svgCircle, svgPath } from './svgElement';
+import { svgGroup, svgLine, svgText, svgCircle, svgPath, Point } from './svgElement';
 
 export interface LineChartData {
   name: string;
@@ -22,7 +22,7 @@ export interface LineChartOptions {
 }
 
 const defaultOptions: LineChartOptions = {
-  lineAnimationDuration: 1,
+  lineAnimationDuration: 1, // 1s
 };
 
 const LEFT_POS = 80;
@@ -225,7 +225,7 @@ export class LineChart {
       throw new Error('Scale Function is undefined.');
     }
 
-    const points = [];
+    const points: Point[] = [];
     const surfaces = svgGroup();
     surfaces.setAttribute('stroke', '#00554d');
     surfaces.setAttribute('stroke-width', '2');
@@ -243,7 +243,6 @@ export class LineChart {
     const $path = svgPath(points.reverse());
 
     // Line의 총 길이 구하기
-
     const l = this.calculateLineLength(points);
     $path.setAttribute('stroke-dasharray', ` 0  ${l} ${l} 0`);
     $path.setAttribute('stroke-dashoffset', `${l}`);

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -150,14 +150,16 @@ export class LineChart {
     xAsixGrid.setAttribute('stroke-dasharray', '1 2');
     xAsixGrid.setAttribute('stroke-width', '1');
 
-    for (let i = 0; i < this.countOfXGrid; i++) {
-      const line = svgLine(
-        this.left + i * this.xGridGap + this.xGridPadding,
-        this.bottom,
-        this.left + i * this.xGridGap + this.xGridPadding,
-        this.top
-      );
-      xAsixGrid.appendChild(line);
+    if (!(this.scaleX && this.scaleY)) {
+      throw new Error('Scale Function is undefined.');
+    }
+
+    if (this.data && this.data.length > 0) {
+      for (const d of this.data) {
+        const x = this.scaleX(d.milliseconds);
+        const line = svgLine(x, this.bottom, x, this.top);
+        xAsixGrid.appendChild(line);
+      }
     }
     this.element.appendChild(xAsixGrid);
   }
@@ -168,15 +170,18 @@ export class LineChart {
     yAsixGrid.setAttribute('stroke-dasharray', '1 2');
     yAsixGrid.setAttribute('stroke-width', '1');
 
-    for (let i = 0; i < this.countOfYGrid; i++) {
-      const line = svgLine(
-        this.left,
-        this.bottom + this.yGridGap * i - this.yGridPadding,
-        this.right,
-        this.bottom + this.yGridGap * i - this.yGridPadding
-      );
-      yAsixGrid.appendChild(line);
+    if (!(this.scaleX && this.scaleY)) {
+      throw new Error('Scale Function is undefined.');
     }
+
+    if (this.data && this.data.length > 0) {
+      for (const d of this.data) {
+        const y = this.scaleY(d.value);
+        const line = svgLine(this.left, y, this.right, y);
+        yAsixGrid.appendChild(line);
+      }
+    }
+
     this.element.appendChild(yAsixGrid);
   }
 
@@ -232,6 +237,15 @@ export class LineChart {
     surfaces.appendChild($path);
     this.element.appendChild(surfaces);
   }
+
+  renderLabels() {
+    this.renderXLabel();
+    this.renderYLabel();
+  }
+
+  renderXLabel() {}
+
+  renderYLabel() {}
 
   static init(element: SVGElement, data: LineChartData[] = [], options: LineChartOptions = {}) {
     new LineChart(element, data, options);

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -25,7 +25,7 @@ export interface LineChartOptions {
 
 const LEFT_POS = 80;
 const TOP_POS = 10;
-const BOTTOM_POS = 450;
+const BOTTOM_POS = 420;
 const RIGHT_POS = 750;
 const VIEWBOX_X_OFFSET = 0;
 const VIEWBOX_Y_OFFSET = 0;

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -1,9 +1,5 @@
-import { transformer } from './scale';
+import { transformer, ScaleFn } from './scale';
 import { svgGroup, svgLine, svgText, svgCircle, svgPath } from './svgElement';
-
-interface ScaleFn {
-  (v: number): number;
-}
 
 export interface LineChartData {
   name: string;

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -28,6 +28,8 @@ const LEFT_POS = 80;
 const TOP_POS = 10;
 const BOTTOM_POS = 420;
 const RIGHT_POS = 750;
+const X_LABEL_PADDING = 20;
+const Y_LABEL_PADDING = 10;
 const VIEWBOX_X_OFFSET = 0;
 const VIEWBOX_Y_OFFSET = 0;
 const VIEWBOX_WIDTH = 800;
@@ -42,6 +44,10 @@ export class LineChart {
   public yGridGap: number = 0;
   public xGridPadding: number = 0;
   public yGridPadding: number = 0;
+
+  public xLabelPadding: number = X_LABEL_PADDING;
+  public yLabelPadding: number = Y_LABEL_PADDING;
+
   public countOfXGrid: number = 0;
   public countOfYGrid: number = 0;
   public maxValueOfXAxis?: number = undefined;
@@ -135,7 +141,7 @@ export class LineChart {
     this.renderAxisGrid();
     this.renderSurfaces();
     this.renderPoints();
-
+    this.renderLabels();
     // TODO: rendering labels
   }
 
@@ -243,7 +249,25 @@ export class LineChart {
     this.renderYLabel();
   }
 
-  renderXLabel() {}
+  renderXLabel() {
+    const xLabelGroup = svgGroup();
+
+    if (!(this.scaleX && this.scaleY)) {
+      throw new Error('Scale Function is undefined.');
+    }
+
+    if (this.data && this.data.length > 0) {
+      for (const d of this.data) {
+        const x = this.scaleX(d.milliseconds);
+        // TODO: Add option callback function formating label;
+        const label = d.datetime.getMonth() + '/' + d.datetime.getDay();
+        const text = svgText(x, this.bottom + this.xLabelPadding, label);
+        text.setAttribute('text-anchor', 'middle');
+        xLabelGroup.appendChild(text);
+      }
+    }
+    this.element.appendChild(xLabelGroup);
+  }
 
   renderYLabel() {}
 

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -17,8 +17,13 @@ interface ProcessedData {
 }
 
 export interface LineChartOptions {
-  [key: string]: number | string | Function | null;
+  [key: string]: any;
+  lineAnimationDuration?: number;
 }
+
+const defaultOptions: LineChartOptions = {
+  lineAnimationDuration: 1,
+};
 
 const LEFT_POS = 80;
 const TOP_POS = 50;
@@ -120,9 +125,9 @@ export class LineChart {
   }
 
   extendSetting(options: LineChartOptions) {
-    let defaultOptions: LineChartOptions = {};
     let newOptions: LineChartOptions = {};
-    for (var property in defaultOptions) {
+    let property: keyof LineChartOptions;
+    for (property in defaultOptions) {
       if (property in options) {
         newOptions[property] = options[property];
       } else {
@@ -249,7 +254,7 @@ export class LineChart {
     animateEl.setAttribute('attributeName', 'stroke-dashoffset');
     animateEl.setAttribute('from', '0');
     animateEl.setAttribute('to', `${l}`);
-    animateEl.setAttribute('dur', `0.5s`);
+    animateEl.setAttribute('dur', `${this.options.lineAnimationDuration}`);
     animateEl.setAttribute('repeatCount', '1');
     animateEl.setAttribute('fill', 'freeze');
     $path.appendChild(animateEl);

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -1,0 +1,180 @@
+import { transformer } from './scale';
+import { svgGroup, svgLine, svgText } from './svgElement';
+
+interface ScaleFn {
+  (v: number): number;
+}
+
+export interface LineChartData {
+  name: string;
+  value: number;
+  datetime: Date;
+  milliseconds?: number;
+}
+
+interface ProcessedData {
+  name: string;
+  value: number;
+  datetime: Date;
+  milliseconds: number;
+}
+
+export interface LineChartOptions {
+  [key: string]: number | string | Function | null;
+}
+
+const LEFT_POS = 80;
+const TOP_POS = 10;
+const BOTTOM_POS = 450;
+const RIGHT_POS = 750;
+const VIEWBOX_X_OFFSET = 0;
+const VIEWBOX_Y_OFFSET = 0;
+const VIEWBOX_WIDTH = 800;
+const VIEWBOX_HEIGHT = 500;
+
+export class LineChart {
+  public left: number;
+  public top: number;
+  public right: number;
+  public bottom: number;
+  public xGridGap: number = 0;
+  public yGridGap: number = 0;
+  public xGridPadding: number = 0;
+  public yGridPadding: number = 0;
+  public countOfXGrid: number = 0;
+  public countOfYGrid: number = 0;
+  public maxValueOfXAxis?: number = undefined;
+  public minValueOfXAxis?: number = undefined;
+  public maxValueOfYAxis?: number = undefined;
+  public minValueOfYAxis?: number = undefined;
+  public scaleX?: ScaleFn = undefined;
+  public scaleY?: ScaleFn = undefined;
+  public element: SVGElement;
+  public options: LineChartOptions;
+  public data?: ProcessedData[];
+
+  constructor(element: SVGElement, data: LineChartData[], options = {}) {
+    if (!(element instanceof Node)) {
+      throw "Can't initialize PieChart because " + element + ' is not a Node.';
+    }
+
+    this.left = LEFT_POS;
+    this.top = TOP_POS;
+    this.right = RIGHT_POS;
+    this.bottom = BOTTOM_POS;
+
+    this.element = element;
+    this.options = this.extendSetting(options);
+    this.data = this.processData(data);
+
+    this.updatePosition();
+    this.renderGraph();
+  }
+
+  processData(data: LineChartData[]): ProcessedData[] {
+    const newData: ProcessedData[] = data.map((d: LineChartData) => {
+      return {
+        name: d.name,
+        value: d.value,
+        datetime: d.datetime,
+        milliseconds: d.datetime.getTime(),
+      };
+    });
+
+    return newData;
+  }
+
+  updatePosition() {
+    this.xGridPadding = 0;
+    this.yGridPadding = 0;
+
+    if (!this.data || this.data.length == 0) {
+      this.countOfYGrid = 1;
+      this.countOfXGrid = 1;
+    } else {
+      const milliseconds = this.data.map(d => d.milliseconds);
+      const values = this.data.map(d => d.value);
+
+      this.maxValueOfXAxis = Math.max(...milliseconds);
+      this.minValueOfXAxis = Math.min(...milliseconds);
+      this.maxValueOfYAxis = Math.max(...values);
+      this.minValueOfYAxis = Math.min(...values);
+
+      this.countOfYGrid = this.data.length + 1;
+      this.countOfXGrid = this.data.length + 1;
+
+      this.scaleX = transformer().domain(this.minValueOfXAxis, this.maxValueOfXAxis).range(this.left, this.right);
+
+      this.scaleY = transformer().domain(this.minValueOfYAxis, this.maxValueOfYAxis).range(this.bottom, this.top);
+
+      this.xGridGap = (this.scaleX(this.maxValueOfXAxis) - this.scaleX(this.minValueOfXAxis)) / this.data.length;
+
+      this.yGridGap = (this.scaleY(this.maxValueOfYAxis) - this.scaleY(this.minValueOfYAxis)) / this.data.length;
+    }
+  }
+
+  extendSetting(options: LineChartOptions) {
+    let defaultOptions: LineChartOptions = {};
+    let newOptions: LineChartOptions = {};
+    for (var property in defaultOptions) {
+      if (property in options) {
+        newOptions[property] = options[property];
+      } else {
+        newOptions[property] = defaultOptions[property];
+      }
+    }
+    return newOptions;
+  }
+
+  renderGraph() {
+    this.element.setAttribute('viewBox', `${VIEWBOX_X_OFFSET} ${VIEWBOX_Y_OFFSET} ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`);
+    this.renderAxisGrid();
+  }
+
+  renderAxisGrid() {
+    this.renderXAxisGrid();
+    this.renderYAxisGrid();
+    // TODO: rendering data point
+    // TODO: rendering labels
+  }
+
+  renderXAxisGrid() {
+    const xAsixGrid = svgGroup();
+    xAsixGrid.setAttribute('stroke', 'black');
+    xAsixGrid.setAttribute('stroke-dasharray', '1 2');
+    xAsixGrid.setAttribute('stroke-width', '1');
+
+    for (let i = 0; i < this.countOfXGrid; i++) {
+      const line = svgLine(
+        this.left + i * this.xGridGap + this.xGridPadding,
+        this.bottom,
+        this.left + i * this.xGridGap + this.xGridPadding,
+        this.top
+      );
+      xAsixGrid.appendChild(line);
+    }
+    this.element.appendChild(xAsixGrid);
+  }
+
+  renderYAxisGrid() {
+    const yAsixGrid = svgGroup();
+    yAsixGrid.setAttribute('stroke', 'black');
+    yAsixGrid.setAttribute('stroke-dasharray', '1 2');
+    yAsixGrid.setAttribute('stroke-width', '1');
+
+    for (let i = 0; i < this.countOfYGrid; i++) {
+      const line = svgLine(
+        this.left,
+        this.bottom + this.yGridGap * i - this.yGridPadding,
+        this.right,
+        this.bottom + this.yGridGap * i - this.yGridPadding
+      );
+      yAsixGrid.appendChild(line);
+    }
+    this.element.appendChild(yAsixGrid);
+  }
+
+  static init(element: SVGElement, data: LineChartData[] = [], options: LineChartOptions = {}) {
+    new LineChart(element, data, options);
+  }
+}

--- a/client/src/utils/charts/duration.ts
+++ b/client/src/utils/charts/duration.ts
@@ -1,0 +1,7 @@
+export const durationSecond = 1000;
+export const durationMinute = durationSecond * 60;
+export const durationHour = durationMinute * 60;
+export const durationDay = durationHour * 24;
+export const durationWeek = durationDay * 7;
+export const durationMonth = durationDay * 30;
+export const durationYear = durationDay * 365;

--- a/client/src/utils/charts/scale.ts
+++ b/client/src/utils/charts/scale.ts
@@ -29,7 +29,13 @@ function bimap(domain: any[], range: any[]) {
 
 let unit = [0, 1];
 
-export function transformer() {
+export interface ScaleFn {
+  (x: number): number;
+  domain: (d0: number, d1: number) => ScaleFn;
+  range: (r0: number, r1: number) => ScaleFn;
+}
+
+export function transformer(): ScaleFn {
   let domain = unit;
   let range = unit;
 

--- a/client/src/utils/charts/scale.ts
+++ b/client/src/utils/charts/scale.ts
@@ -1,0 +1,57 @@
+import { durationDay } from './duration';
+
+function normalize(a: number, b: number) {
+  return b - a
+    ? function (x: number) {
+        return (x - a) / (b - a);
+      }
+    : function () {
+        return isNaN(b) ? NaN : 0.5;
+      };
+}
+
+function interpolate(a: number, b: number) {
+  // same with (b - a) * t + a
+  return (t: number) => a * (1 - t) + b * t;
+}
+
+function bimap(domain: any[], range: any[]) {
+  let d0 = domain[0],
+    d1 = domain[1];
+  let r0 = range[0],
+    r1 = range[1];
+  let normalizer: (n: number) => number;
+  let interpolater: (t: number) => number;
+
+  normalizer = d1 < d0 ? normalize(d1, d0) : normalize(d0, d1);
+  interpolater = interpolate(r0, r1);
+
+  return (x: number) => interpolater(normalizer(x));
+}
+
+let unit = [0, 1];
+
+export function transformer() {
+  let domain = unit;
+  let range = unit;
+
+  function rescale() {
+    return scale;
+  }
+
+  function scale(x: number) {
+    return bimap(domain, range)(x);
+  }
+
+  scale.domain = function (d0: number, d1: number) {
+    domain = [d0, d1];
+    return rescale();
+  };
+
+  scale.range = function (r0: number, r1: number) {
+    range = [r0, r1];
+    return rescale();
+  };
+
+  return rescale();
+}

--- a/client/src/utils/charts/scale.ts
+++ b/client/src/utils/charts/scale.ts
@@ -1,5 +1,3 @@
-import { durationDay } from './duration';
-
 function normalize(a: number, b: number) {
   return b - a
     ? function (x: number) {

--- a/client/src/utils/charts/svgElement.ts
+++ b/client/src/utils/charts/svgElement.ts
@@ -16,3 +16,32 @@ export const svgText = (x: number, y: number, text = '') => {
   $text.textContent = text;
   return $text;
 };
+
+export const svgCircle = (x: number, y: number, r: number) => {
+  const $circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  $circle.setAttribute('cx', `${x}`);
+  $circle.setAttribute('cy', `${y}`);
+  $circle.setAttribute('r', `${r}`);
+  return $circle;
+};
+
+export const svgPath = (points: number[][]) => {
+  const $path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+  // M113,360 L113,192 L259,171 L405,179 L551,200 L697,204 L697,360 Z
+  const pathData = [];
+  if (points.length > 0) {
+    const x = points[0][0];
+    const y = points[0][1];
+    const start = `M${x},${y}`;
+    pathData.push(start);
+    points.slice(1).forEach(point => {
+      const x = point[0],
+        y = point[1];
+      pathData.push(`L${x},${y}`);
+    });
+  }
+
+  $path.setAttribute('d', pathData.join(' '));
+  return $path;
+};

--- a/client/src/utils/charts/svgElement.ts
+++ b/client/src/utils/charts/svgElement.ts
@@ -25,7 +25,9 @@ export const svgCircle = (x: number, y: number, r: number) => {
   return $circle;
 };
 
-export const svgPath = (points: number[][]) => {
+export type Point = [number, number];
+
+export const svgPath = (points: Point[]) => {
   const $path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
   // M113,360 L113,192 L259,171 L405,179 L551,200 L697,204 L697,360 Z

--- a/client/src/utils/charts/svgElement.ts
+++ b/client/src/utils/charts/svgElement.ts
@@ -1,0 +1,18 @@
+export const svgLine = (x1: number, y1: number, x2: number, y2: number) => {
+  const $line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  $line.setAttribute('x1', `${x1}`);
+  $line.setAttribute('y1', `${y1}`);
+  $line.setAttribute('x2', `${x2}`);
+  $line.setAttribute('y2', `${y2}`);
+  return $line;
+};
+
+export const svgGroup = () => document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+export const svgText = (x: number, y: number, text = '') => {
+  const $text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  $text.setAttribute('x', x.toString());
+  $text.setAttribute('y', y.toString());
+  $text.textContent = text;
+  return $text;
+};


### PR DESCRIPTION
https://github.com/woowa-techcamp-2021/cashbook-5/issues/9

## 개요

Ledger 데이터를 통계해서 보여주기위해 라인차트를 추가 구현했습니다.

현재는 하나의 카테고리 데이터를 보여주기만 합니다.

여러 카테고리를 동시에 보여주는 기능은 추가 구현이 필요해보입니다. (코드량을 많이 추가하고 x축 라벨을 어떻게 나타내야할지 고민이 많이 생깁니다.

구체적인 기능과 원리는 WIKI에 따로 정리할 필요가 있으니 정리해놓겠습니다.

혹시 리뷰하다가 코드가 너무 이해안되는 부분이 있으면 말씀해주세요. 저도 라이브러리처럼 만들어 보려고 하는데 쉽지않네요.


## 변경사항

`/util/charts/LineChart.ts` 에 실제 구현이 있으면 도메인 값을 svg 에서의 범위로 변환해주는 scale함수를 따로 모듈화해놨습니다.

- [ ]  여러 카테고리를 데이터를 표시할 수 있다. 추후 기능 추가할 예정
- [x]  데이터에 따라 X, Y 축 라벨을 보여줄 수 있다.
- [x]  데이터상태에 따라 Grid 를 보여줄 수 있다.
 
LineChart 생성을 하면  전체적인 흐름이 아래 순서로 이뤄집니다.

- 데이터의 x이 될 datetime 을 timestamp값으로 변환하고 
- x축 스케일 함수와 y축 스케일 함수를 생성합니다. (데이터 도메인에 따라 화면 크기에 맞는 그래프를 그리기 위해)
-  x,y축을 그립니다.
- 각 데이터 포인터(점)을 그립니다. 미리 만든 스케일 함수 활용해서 좌표를 지정
- 데이터 포인터를 이을 선을 생성(`path` 태그 이용)
- 마지막으로 각 x,y축 라벨을 알맞은 위치에 생성

## 참고사항

## 추가 구현 필요사항

## 스크린샷
<img width="758" alt="스크린샷 2021-07-31 오후 9 50 50" src="https://user-images.githubusercontent.com/20085849/127740408-8f84a261-485f-49cd-a8ad-b9001df808e3.png">
