### PR TITLE
[#50] 캘린더 페이지 리팩토링

### DIFF
--- a/client/src/api/ledgerAPI.ts
+++ b/client/src/api/ledgerAPI.ts
@@ -1,0 +1,87 @@
+import { ILedger } from '../interfaces/Ledger';
+
+interface Result<D> {
+  success: boolean;
+  data: D;
+}
+
+export interface PaymentType {
+  numDate: string;
+  date: string;
+  day: string;
+  income: number;
+  spand: number;
+  ledgers: ILedger[];
+}
+
+export const getLedgerData = async (date: Date): Promise<Result<PaymentType[]>> => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve({
+        success: true,
+        data: [
+          {
+            numDate: '0627',
+            date: '06월 26일',
+            day: '화',
+            income: 200000,
+            spand: -150000,
+            ledgers: [
+              {
+                categoryType: '6',
+                category: '미분류',
+                content: '아이 몰라몰라',
+                cardType: '현금',
+                amount: -100000,
+              },
+              {
+                categoryType: '4',
+                category: '식비',
+                content: '저녁밥',
+                cardType: '현대카드',
+                amount: -50000,
+              },
+              {
+                categoryType: '8',
+                category: '월급',
+                content: '7월 급여',
+                cardType: '현급',
+                amount: 200000,
+              },
+            ],
+          },
+          {
+            numDate: '0628',
+            date: '06월 25일',
+            day: '수',
+            income: 300000,
+            spand: -200000,
+            ledgers: [
+              {
+                categoryType: '6',
+                category: '미분류',
+                content: '아이 몰라몰라',
+                cardType: '국민카드',
+                amount: -150000,
+              },
+              {
+                categoryType: '4',
+                category: '식비',
+                content: '저녁밥',
+                cardType: '삼성카드',
+                amount: -50000,
+              },
+              {
+                categoryType: '8',
+                category: '월급',
+                content: '7월 보너스',
+                cardType: '현급',
+                amount: 300000,
+              },
+            ],
+          },
+        ],
+      });
+    }, 500);
+  });
+};

--- a/client/src/components/Calendar/index.scss
+++ b/client/src/components/Calendar/index.scss
@@ -64,6 +64,9 @@
         .spand {
           color: $error;
         }
+        .amount {
+          color: $text-color;
+        }
       }
     }
 

--- a/client/src/components/Calendar/index.ts
+++ b/client/src/components/Calendar/index.ts
@@ -12,12 +12,15 @@ interface IState {
   ledgerData: ILedgerList[];
 }
 
-interface IProps {}
+interface IProps {
+  date: Date;
+  ledgerData: ILedgerList[];
+}
 
 export default class calendar extends Component<IState, IProps> {
   setup() {
-    this.$state.ledgerData = LedgerDataModel.getData();
-    this.$state.date = new Date();
+    this.$state.ledgerData = this.$props.ledgerData;
+    this.$state.date = this.$props.date;
   }
 
   template() {
@@ -26,6 +29,14 @@ export default class calendar extends Component<IState, IProps> {
               <ul class="body"></ul>
             </div>
             <div class="day-ledger-info"></div>`;
+  }
+
+  mounted() {
+    this.renderCalendar();
+    this.renderLedgersInCalendar();
+
+    const calendarBody = qs('.calendar-container .body', this.$target) as HTMLElement;
+    calendarBody.addEventListener('click', this.showDayLedger.bind(this));
   }
 
   renderCalendar() {
@@ -82,20 +93,11 @@ export default class calendar extends Component<IState, IProps> {
         key += viewMonth < 10 ? '0' + viewMonth : viewMonth;
         key += day < 10 ? '0' + day : day;
 
-        return html`
-        <li class="date" ${condition ? `data-key="${key}"` : ''}>
+        return html` <li class="date" ${condition ? `data-key="${key}"` : ''}>
           <div ${condition ? '' : 'class="other"'}>${day}</div>
         </li>`;
       })
       .join('');
-  }
-
-  mounted() {
-    this.renderCalendar();
-    this.renderLedgersInCalendar();
-
-    const calendarBody = qs('.calendar-container .body', this.$target) as HTMLElement;
-    calendarBody.addEventListener('click', this.showDayLedger.bind(this));
   }
 
   renderLedgersInCalendar() {
@@ -106,7 +108,7 @@ export default class calendar extends Component<IState, IProps> {
 
       const day = qs(`li[data-key="${numDate}"]`, this.$target) as HTMLElement;
 
-      day.insertAdjacentHTML(
+      day?.insertAdjacentHTML(
         'beforeend',
         `<div class="day-amount">
         <div class="income">${addComma(income)}</div>

--- a/client/src/components/LedgerContainer/index.ts
+++ b/client/src/components/LedgerContainer/index.ts
@@ -14,11 +14,13 @@ interface IState {
   checked?: string[];
 }
 
-interface IProps {}
+interface IProps {
+  ledgerData: ILedgerList[];
+}
 
 export default class LedgerContainer extends Component<IState, IProps> {
   setup() {
-    this.$state.ledgerData = LedgerDataModel.getData();
+    this.$state.ledgerData = this.$props.ledgerData;
     this.$state.totalCount = 0;
     this.$state.totalIncomes = 0;
     this.$state.totalSpand = 0;

--- a/client/src/components/MonthPicker.ts
+++ b/client/src/components/MonthPicker.ts
@@ -34,7 +34,7 @@ export default class MonthPicker {
 
   style() {
     return ` 
-      .calendar-wrapper {
+      .month-calendar-wrapper {
         position: absolute;
         bottom: 0;
         background: var(--background-color);
@@ -46,30 +46,30 @@ export default class MonthPicker {
         transform: translate(-50%, 110%);
         box-shadow: 0 3px 5px grey;
       }
-      .calendar-wrapper .calendar-inner {
+      .month-calendar-wrapper .month-calendar-inner {
         position: relative;
         z-index:9;
       }
-      .calendar-wrapper .calendar-header {
+      .month-calendar-wrapper .month-calendar-header {
         display: flex;
         justify-content: space-around;
         align-items: center;
       }
-      .calendar-wrapper .calendar-header div {
+      .month-calendar-wrapper .month-calendar-header div {
         cursor: pointer;
       }
-      .calendar-wrapper .calendar-body {
+      .month-calendar-wrapper .month-calendar-body {
         display: grid;
         grid-template-columns: repeat(4, 1fr);
         grid-column-gap: .5em;
         padding: 1em 1em 0;
       }
-      .calendar-wrapper .calendar-body .month {
+      .month-calendar-wrapper .month-calendar-body .month {
         padding: 10px;
         cursor: pointer;
       }
 
-      .calendar-wrapper .calendar-body .month.selected { 
+      .month-calendar-wrapper .month-calendar-body .month.selected { 
         background: var(--primary-color);
         border-radius: 9px;
       }
@@ -79,17 +79,17 @@ export default class MonthPicker {
   template() {
     const currentYear = this.date.getFullYear() == this.year;
     return html`
-      <div class="calendar-wrapper">
+      <div class="month-calendar-wrapper">
         <style>
           ${this.style()}
         </style>
-        <div class="calendar-inner">
-          <div class="calendar-header">
+        <div class="month-calendar-inner">
+          <div class="month-calendar-header">
             <div class="prev"><</div>
             <div class="year">${this.year}</div>
             <div class="next">></div>
           </div>
-          <div class="calendar-body">
+          <div class="month-calendar-body">
             ${this.monthShortName
               .map((month, i) => {
                 return html`
@@ -109,14 +109,14 @@ export default class MonthPicker {
   }
 
   render() {
-    const MonthPicker = document.querySelector('.calendar-wrapper') as HTMLElement;
+    const MonthPicker = document.querySelector('.month-calendar-wrapper') as HTMLElement;
     MonthPicker?.remove();
     this.$target.insertAdjacentHTML('afterend', this.template());
     this.mounted();
   }
 
   mounted() {
-    const MonthPicker = document.querySelector('.calendar-wrapper') as HTMLElement;
+    const MonthPicker = document.querySelector('.month-calendar-wrapper') as HTMLElement;
     const prev = MonthPicker.querySelector('.prev') as HTMLElement;
     const next = MonthPicker.querySelector('.next') as HTMLElement;
 

--- a/client/src/components/SnackBar/index.scss
+++ b/client/src/components/SnackBar/index.scss
@@ -24,7 +24,7 @@
   top: -20%;
   left: 50%;
   overflow: hidden;
-  box-shadow: 0px 1px 4px $body;
+  box-shadow: 0px 1px 4px $line;
   transform: translateX(-50%);
   background: $background;
   padding: 0.5em 1.5em;

--- a/client/src/models/Ledgers.ts
+++ b/client/src/models/Ledgers.ts
@@ -1,3 +1,4 @@
+import { getLedgerData } from '../api/ledgerAPI';
 import { ILedger, ILedgerList } from '../interfaces/Ledger';
 import Observer from './Observer';
 
@@ -90,9 +91,14 @@ export class LedgerDataModel extends Observer {
         return list;
       });
   }
-  setDate(data: ILedgerList[]) {
+  setData(data: ILedgerList[]) {
     this.ledgerData = data;
     this.notify();
+  }
+  async update(date: Date) {
+    //TODO LEDGERS DATA UPDATE
+    const newLedgerData = await (await getLedgerData(date)).data;
+    this.ledgerData = newLedgerData;
   }
 }
 

--- a/client/src/pages/CalendarPage/index.ts
+++ b/client/src/pages/CalendarPage/index.ts
@@ -1,18 +1,36 @@
 import Calendar from '@/src/components/Calendar';
 import Component from '@/src/core/Component';
+import { ILedgerList } from '@/src/interfaces/Ledger';
+import CalendarModel from '@/src/models/Calendar';
+import LedgerDataModel from '@/src/models/Ledgers';
 import './index.scss';
 
-interface IState {}
+interface IState {
+  ledgerData: ILedgerList[];
+  date: Date;
+}
 interface IProps {}
 
 export default class CalendarPages extends Component<IState, IProps> {
+  setup() {
+    this.$state.ledgerData = LedgerDataModel.getData();
+    this.$state.date = CalendarModel.getDate();
+  }
   template() {
     return `<div class="calendar-wrapper"></div>`;
   }
 
   mounted() {
     const target = this.$target.querySelector('.calendar-wrapper') as HTMLElement;
+    const { ledgerData, date } = this.$state;
+    new Calendar(target, { ledgerData, date });
+  }
 
-    new Calendar(target);
+  setEvent() {
+    const target = this.$target.querySelector('.calendar-wrapper') as HTMLElement;
+    CalendarModel.subscribe(async () => {
+      await LedgerDataModel.update(CalendarModel.getDate());
+      new Calendar(target, { ledgerData: LedgerDataModel.getData(), date: CalendarModel.getDate() });
+    });
   }
 }

--- a/client/src/pages/MainPage/index.ts
+++ b/client/src/pages/MainPage/index.ts
@@ -4,12 +4,20 @@ import Component from '@/src/core/Component';
 import LedgerAddButton from '@/src/components/LedgerAddButton';
 
 import './index.scss';
+import LedgerDataModel from '@/src/models/Ledgers';
+import CalendarModel from '@/src/models/Calendar';
+import { ILedgerList } from '@/src/interfaces/Ledger';
 
 interface IState {}
 
-interface IProps {}
+interface IProps {
+  ledgerData: ILedgerList[];
+}
 
 export default class MainPage extends Component<IProps, IState> {
+  setup() {
+    this.$state.ledgerData = LedgerDataModel.getData();
+  }
   template() {
     return /* html */ `
         <div id='body'></div>
@@ -21,7 +29,8 @@ export default class MainPage extends Component<IProps, IState> {
 
   mounted() {
     const body = this.$target.querySelector('#body') as HTMLElement;
-    new LedgerContainer(body);
+    const { ledgerData } = this.$state;
+    new LedgerContainer(body, { ledgerData });
 
     const $addModal = this.$target.querySelector('#ledger-add-modal') as HTMLElement;
     const ledgerAddModal = new LedgerAddModal($addModal);
@@ -29,6 +38,15 @@ export default class MainPage extends Component<IProps, IState> {
     const $addLedgerButton = this.$target.querySelector('#ledger-add-button') as HTMLElement;
     new LedgerAddButton($addLedgerButton, {
       onClick: () => ledgerAddModal.show(),
+    });
+  }
+
+  setEvent() {
+    const body = this.$target.querySelector('#body') as HTMLElement;
+    CalendarModel.subscribe(async () => {
+      await LedgerDataModel.update(CalendarModel.getDate());
+      console.log(LedgerDataModel);
+      new LedgerContainer(body, { ledgerData: LedgerDataModel.getData() });
     });
   }
 }


### PR DESCRIPTION
#50

## 개요
## 변경사항
메인 페이지에서 캘린더 옵저버 구독
하위 컴포넌트로 상태전달
insertAdject 관련 오류 수정
캘린더 페이지에서 month picker 출현시 캘린더가 없어지는 오류 수정
ledger DATA api 형태로 변경

## 참고사항
## 추가 구현 필요사항
ledger 옵저버의 경우 서버에서 받아오는 형태로만 진행할 예정으로 추후 삭제 진행 예정

## 스크린샷
