### PR TITLE
 [#9] 라인차트 여러 카테고리를 동시에 보여주는 기능 추가 구현

### DIFF
--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -1,5 +1,5 @@
 import Component from '@/src/core/Component';
-import { LineChart, LineChartData } from '@/src/utils/charts/LineChart';
+import { LineChart, LineGroupChartData, LineChartData } from '@/src/utils/charts/LineChart';
 import PieChart, { PieChartData } from '@/src/utils/charts/PieChart';
 
 import './index.scss';
@@ -13,44 +13,57 @@ const mockDataByCategory: PieChartData[] = [
   { name: '적금', value: 30, color: '#00ab6b' },
 ];
 
-const mockDataByDate: LineChartData[] = [
-  {
-    name: 'A',
-    datetime: new Date('2021-07-21'),
-    value: 10,
+const mockDataByDate: LineGroupChartData = {
+  적금: {
+    data: [
+      {
+        name: 'A',
+        datetime: new Date('2021-07-21'),
+        value: 10,
+      },
+      {
+        name: 'B',
+        datetime: new Date('2021-07-22'),
+        value: 30,
+      },
+      {
+        name: 'B',
+        datetime: new Date('2021-07-24'),
+        value: 50,
+      },
+    ],
+    color: '#ff0000',
   },
-  {
-    name: 'B',
-    datetime: new Date('2021-07-22'),
-
-    value: 30,
+  예금: {
+    data: [
+      {
+        name: 'C',
+        datetime: new Date('2021-07-21'),
+        value: 50,
+      },
+      {
+        name: 'D',
+        datetime: new Date('2021-07-22'),
+        value: 40,
+      },
+      {
+        name: 'D',
+        datetime: new Date('2021-07-23'),
+        value: 50,
+      },
+      {
+        name: 'D',
+        datetime: new Date('2021-07-24'),
+        value: 5,
+      },
+    ],
+    color: '#00ff00',
   },
-  {
-    name: 'C',
-    datetime: new Date('2021-07-23'),
-
-    value: 50,
-  },
-  {
-    name: 'D',
-    datetime: new Date('2021-07-24'),
-    value: 40,
-  },
-  {
-    name: 'D',
-    datetime: new Date('2021-07-25'),
-    value: 50,
-  },
-  {
-    name: 'D',
-    datetime: new Date('2021-07-26'),
-    value: 5,
-  },
-];
+};
 
 interface IState {
   dataByCategory?: PieChartData[];
-  dataByDate?: LineChartData[];
+  dataByDate?: LineGroupChartData;
 }
 interface IProps {}
 
@@ -72,7 +85,7 @@ export default class StatisticPage extends Component<IState, IProps> {
   }
 
   setup() {
-    this.$state = { dataByCategory: [], dataByDate: [] };
+    this.$state = { dataByCategory: [], dataByDate: {} };
     setTimeout(() => {
       this.setState({
         dataByCategory: mockDataByCategory,
@@ -91,9 +104,7 @@ export default class StatisticPage extends Component<IState, IProps> {
       },
     });
 
-    if (this.$state.dataByDate && this.$state.dataByDate.length > 0) {
-      const $lineChart = document.querySelector('#line-chart') as SVGElement;
-      LineChart.init($lineChart, dataByDate);
-    }
+    const $lineChart = document.querySelector('#line-chart') as SVGElement;
+    LineChart.init($lineChart, dataByDate);
   }
 }

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -59,6 +59,26 @@ const mockDataByDate: LineGroupChartData = {
     ],
     color: '#00ff00',
   },
+  현금: {
+    data: [
+      {
+        name: 'A',
+        datetime: new Date('2021-07-21'),
+        value: 10,
+      },
+      {
+        name: 'B',
+        datetime: new Date('2021-07-22'),
+        value: 24,
+      },
+      {
+        name: 'B',
+        datetime: new Date('2021-07-24'),
+        value: 30,
+      },
+    ],
+    color: '#000000',
+  },
 };
 
 interface IState {

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -31,10 +31,14 @@ interface ProcessedLineChartData {
 export interface LineChartOptions {
   [key: string]: any;
   lineAnimationDuration?: number;
+  xLabelFontSize?: string;
+  yLabelFontSize?: string;
 }
 
 const defaultOptions: LineChartOptions = {
   lineAnimationDuration: 0.4, // 0.4s
+  xLabelFontSize: '1.5em',
+  yLabelFontSize: '1.5em',
 };
 
 const LEFT_POS = 80;
@@ -260,7 +264,6 @@ export class LineChart {
     const $path = svgPath(points.reverse());
 
     // Line의 총 길이 구하기
-
     const l = this.calculateLineLength(points);
     console.log(items, l);
     $path.setAttribute('stroke-dasharray', ` 0  ${l} ${l} 0`);
@@ -300,6 +303,8 @@ export class LineChart {
         const label = d.datetime.getMonth() + '/' + d.datetime.getDate();
         const text = svgText(x, this.bottom + this.xLabelPadding, label);
         text.setAttribute('text-anchor', 'middle');
+        text.setAttribute('font-size', this.options.xLabelFontSize || '');
+
         xLabelGroup.appendChild(text);
       }
     }
@@ -319,6 +324,7 @@ export class LineChart {
         // TODO: Add option callback function formating label;
         const text = svgText(this.left - this.yLabelPadding, y, d.value.toString());
         text.setAttribute('text-anchor', 'end');
+        text.setAttribute('font-size', this.options.yLabelFontSize || '');
         yLabelGroup.appendChild(text);
       }
     }

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -33,12 +33,16 @@ export interface LineChartOptions {
   lineAnimationDuration?: number;
   xLabelFontSize?: string;
   yLabelFontSize?: string;
+  lineOpacity?: number;
+  lineWidth?: number;
 }
 
 const defaultOptions: LineChartOptions = {
   lineAnimationDuration: 0.4, // 0.4s
-  xLabelFontSize: '1.5em',
-  yLabelFontSize: '1.5em',
+  xLabelFontSize: '1em',
+  yLabelFontSize: '1em',
+  lineOpacity: 0.5,
+  lineWidth: 3,
 };
 
 const LEFT_POS = 80;
@@ -246,12 +250,12 @@ export class LineChart {
     }
 
     const points: Point[] = [];
-    const surfaces = svgGroup();
+    const lines = svgGroup();
 
-    surfaces.setAttribute('stroke', color);
-    surfaces.setAttribute('stroke-width', '2');
-    surfaces.setAttribute('fill', 'none');
-    surfaces.setAttribute('stroke-opacity', '0.5');
+    lines.setAttribute('stroke', color);
+    lines.setAttribute('stroke-width', this.options.lineWidth?.toString() || '3');
+    lines.setAttribute('stroke-opacity', this.options.lineOpacity?.toString() || '0.5');
+    lines.setAttribute('fill', 'none');
 
     if (items && items.length > 0) {
       for (const item of items) {
@@ -280,8 +284,8 @@ export class LineChart {
     animateEl.setAttribute('fill', 'freeze');
     $path.appendChild(animateEl);
 
-    surfaces.appendChild($path);
-    this.element.appendChild(surfaces);
+    lines.appendChild($path);
+    this.element.appendChild(lines);
   }
 
   renderLabels(items: ProcessedLineChartData[]) {

--- a/client/src/utils/charts/PieChart.ts
+++ b/client/src/utils/charts/PieChart.ts
@@ -40,7 +40,7 @@ export default class PieChart {
     this.settings = this.extendSetting(settings);
     this.data = this.processData(data);
     this.viewboxSetting();
-    this.update();
+    this.renderGraph();
   }
 
   extendSetting(options: PieChartOption) {
@@ -73,7 +73,7 @@ export default class PieChart {
     });
   }
 
-  update() {
+  renderGraph() {
     const r = <number>this.settings.radius;
     let cumulativePercent = 0;
     this.data.forEach(entry => {


### PR DESCRIPTION
#9 

## 개요

기존에 라인차트는 하나의 카테고리 데이터(하나의 라인)만을 보여줄 수 있었지만 필요에 의해 여러개의 라인을 보여줄 필요가 있어서 LineChart가 받는 데이터 형태를 수정해서 여러 라인을 보여줄 수 있도록 수정 했습니다.

## 변경사항

`LineChartData`를 직접 받는게 아니라 데이터를 한번 감싸는 `LineGroupChartData`를 입력 데이터로 받도록 변경했습니다.

## 참고사항

추가로 필요한 Option들을 추가했습니다.
- Line Opacity
- Line Width
- X,Y Label Font Size

## 추가 구현 필요사항

데이터 포인터(점)에 호버했을 때 툴팁을 추가할 필요가 있음.

## 스크린샷
<img width="694" alt="스크린샷 2021-08-01 오후 3 03 32" src="https://user-images.githubusercontent.com/20085849/127761081-e08d2033-579b-4866-9d17-56d83b5a51fb.png">
