### PR TITLE
StatisticPage 에서 Pie, Line 차트를 위한 데이터 변환 작업

### DIFF
--- a/client/src/api/statisticAPI.ts
+++ b/client/src/api/statisticAPI.ts
@@ -49,7 +49,7 @@ export const getStatisticLedgers = async (): Promise<Result<StatisticLedgerByCat
               { datetime: new Date('2021-08-29'), value: 70000 },
               { datetime: new Date('2021-08-30'), value: 80000 },
             ],
-            total: 100000,
+            total: 500000,
             color: '#00ff00',
           },
         },

--- a/client/src/api/statisticAPI.ts
+++ b/client/src/api/statisticAPI.ts
@@ -1,0 +1,59 @@
+interface Result<D> {
+  success: boolean;
+  data: D;
+}
+
+interface DateValueEntry {
+  datetime: Date;
+  value: number;
+}
+
+export interface StatisticLedgerByCategory {
+  [category: string]: {
+    entries: DateValueEntry[];
+    total: number;
+    color: string;
+  };
+}
+
+export const getStatisticLedgers = async (): Promise<Result<StatisticLedgerByCategory>> => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve({
+        success: true,
+        data: {
+          용돈: {
+            entries: [
+              { datetime: new Date('2021-08-27'), value: 10000 },
+              { datetime: new Date('2021-08-28'), value: 30000 },
+              { datetime: new Date('2021-08-29'), value: 50000 },
+              { datetime: new Date('2021-08-30'), value: 10000 },
+            ],
+            total: 100000,
+            color: '#000000',
+          },
+          적금: {
+            entries: [
+              { datetime: new Date('2021-08-27'), value: 10000 },
+              { datetime: new Date('2021-08-28'), value: 20000 },
+              { datetime: new Date('2021-08-29'), value: 50000 },
+              { datetime: new Date('2021-08-30'), value: 80000 },
+            ],
+            total: 100000,
+            color: '#ff0000',
+          },
+          예금: {
+            entries: [
+              { datetime: new Date('2021-08-27'), value: 10000 },
+              { datetime: new Date('2021-08-28'), value: 30000 },
+              { datetime: new Date('2021-08-29'), value: 70000 },
+              { datetime: new Date('2021-08-30'), value: 80000 },
+            ],
+            total: 100000,
+            color: '#00ff00',
+          },
+        },
+      });
+    }, 500);
+  });
+};

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -56,7 +56,7 @@ const VIEWBOX_Y_OFFSET = 0;
 const VIEWBOX_WIDTH = 800;
 const VIEWBOX_HEIGHT = 500;
 
-export class LineChart {
+export default class LineChart {
   public left: number;
   public top: number;
   public right: number;
@@ -269,7 +269,6 @@ export class LineChart {
 
     // Line의 총 길이 구하기
     const l = this.calculateLineLength(points);
-    console.log(items, l);
     $path.setAttribute('stroke-dasharray', ` 0  ${l} ${l} 0`);
     $path.setAttribute('stroke-dashoffset', `${l}`);
 

--- a/client/src/utils/charts/PieChart.ts
+++ b/client/src/utils/charts/PieChart.ts
@@ -74,15 +74,28 @@ export default class PieChart {
   renderGraph() {
     const r = <number>this.settings.radius;
     let cumulativePercent = 0;
+
     this.data.forEach(entry => {
       if (entry.percent === undefined) {
         throw 'Pie Chart Percent Calculate is fail.';
       }
-      const [startX, startY] = this.getCoordinatesForPercent(cumulativePercent);
 
+      let startPercent = cumulativePercent;
+      let endPercent = cumulativePercent + entry.percent;
       cumulativePercent += entry.percent;
 
-      const [endX, endY] = this.getCoordinatesForPercent(cumulativePercent);
+      const [startX, startY] = this.getCoordinatesForPercent(startPercent);
+      const [endX, endY] = this.getCoordinatesForPercent(endPercent);
+      const [middleX, middleY] = this.getCoordinatesForPercent((startPercent + endPercent) / 2);
+
+      const textEl = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      textEl.setAttribute('x', (middleX * r).toString());
+      textEl.setAttribute('y', (middleY * r).toString());
+      textEl.setAttribute('text-anchor', 'middle');
+      textEl.setAttribute('font-size', '1.2em');
+
+      textEl.textContent = entry.name;
+      textEl.style.pointerEvents = 'none';
 
       const largeArcFlag = entry.percent > 0.5 ? 1 : 0;
 
@@ -96,19 +109,22 @@ export default class PieChart {
       pathEl.setAttribute('d', pathData);
       pathEl.setAttribute('fill', 'none');
       if (entry.color) pathEl.setAttribute('stroke', entry.color);
-      pathEl.setAttribute('stroke-width', (r * 0.8).toString());
-      pathEl.setAttribute('opacity', '0.7');
+      pathEl.setAttribute('stroke-width', r.toString());
+      pathEl.setAttribute('opacity', '0.2');
 
       pathEl.addEventListener('mouseover', () => {
-        pathEl.style.opacity = '1';
+        pathEl.style.opacity = '0.7';
         pathEl.style.transform = `scale(${this.settings.hoverScaleRate})`;
         pathEl.style.transition = `transform ${this.settings.hoverEffectSpeed}s 0s ease`;
+        textEl.style.transform = `scale(${this.settings.hoverScaleRate})`;
+        textEl.style.transition = `transform ${this.settings.hoverEffectSpeed}s 0s ease`;
       });
 
       pathEl.addEventListener('mouseout', () => {
         setTimeout(() => {
-          pathEl.style.opacity = `0.7`;
+          pathEl.style.opacity = `0.5`;
           pathEl.style.transform = '';
+          textEl.style.transform = '';
         }, 100);
       });
 
@@ -137,8 +153,8 @@ export default class PieChart {
       animateEl.setAttribute('repeatCount', '1');
       animateEl.setAttribute('fill', 'freeze');
       pathEl.appendChild(animateEl);
-
       this.element.appendChild(pathEl);
+      this.element.appendChild(textEl);
     });
   }
 

--- a/client/src/utils/charts/PieChart.ts
+++ b/client/src/utils/charts/PieChart.ts
@@ -1,5 +1,3 @@
-import { prototype } from 'webpack-dev-server';
-
 const defaultOptions: PieChartOption = {
   radius: 100,
   hoverScaleRate: 1.3,


### PR DESCRIPTION
## 개요

Pie차트와 Line 차트를 위한 데이터 변환작업을 추가 했습니다.

## 변경사항

Pie 차트에서 사용되는 데이터 형태와 Line 차트에서 사용되는 데이터 형태는 매우 다르기 때문에 

서버쪽에서는 적절한 데이터 형태를 정의해야합니다.

- 서버에서 보내주는 데이터 형태 
```json
{
"success":true,
"data": {
   "용돈": {
        "entries": [
          {"datetime": "2021/08/01", "value":3000},
          {"datetime": "2021/08/02", "value":3000},
          {"datetime": "2021/08/03", "value":3000},
        ], 
        "total": 9000,
     	"color": "#ff0000"
    },
    "적금": {
        "entries": [
          {"datetime": "2021/08/01", "value":3000},
          {"datetime": "2021/08/02", "value":3000},
          {"datetime": "2021/08/03", "value":3000},
        ], 
        "total": 9000,
        "color": "#ff0000"
    }
}
}
```

#57  해당 이슈에서 데이터형태(`StatisticLedgerByCategory` interface 참고)를 정의해놨습니다.

```javascript
mapToPieChartData(data: StatisticLedgerByCategory): PieChartData[] { ... }
```

위는 파이차트를 위한 데이터 생성을 위한 함수입니다.

```javascript
mapToLineChartData(data: StatisticLedgerByCategory): LineGroupChartData { ... }
```

위는 Line차트를 위한 데이터 생성을 위한 함수입니다.

## 참고사항

## 추가 구현 필요사항

- 파이차트 옆에 각 데이터를 태그, 몇 퍼센트 텍스트 형태로 보여주는 표를 추가해줘야합니다.
- 파이, 라인차트에서 마우스 이벤트에 의해 표 및 데이터를 보여주는 방식(툴팁)을 추가해야합니다.
- x축 (날짜) label 포맷을 정하는 콜백함수를 option으로 받을 수 있도록 해야할 것 같습니다.

## 스크린샷

임시 데이터를 넣었을 때 정상적으로 데이터를 보여주는 그래프 모양

<img width="631" alt="스크린샷 2021-08-01 오후 11 13 45" src="https://user-images.githubusercontent.com/20085849/127774067-c8605c91-8c0a-4762-ac7a-8d8c89dfcb43.png">

