### PR TITLE
 Pie Chart 클릭시 특정 카테고리만 Line 차트로 그리는 작업 추가

### DIFF
--- a/client/src/components/Calendar/index.ts
+++ b/client/src/components/Calendar/index.ts
@@ -3,7 +3,7 @@ import { ILedgerList } from '@/src/interfaces/Ledger';
 import LedgerDataModel from '@/src/models/Ledgers';
 import { YOIL_ENG_SHORT } from '@/src/utils/calendar';
 import { addComma, html } from '@/src/utils/codeHelper';
-import { qs } from '@/src/utils/selecthelper';
+import { qs } from '@/src/utils/selectHelper';
 import LedgerList from '../LedgerList';
 import './index.scss';
 

--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -6,10 +6,10 @@ import SvgIcon from '@/src/assets/svg';
 import MonthPicker from '../MonthPicker';
 import { router } from '@/src/core/router';
 import { html, sibling } from '@/src/utils/codeHelper';
-import { qs } from '@/src/utils/selecthelper';
+import { qs } from '@/src/utils/selectHelper';
 import { checkUser } from '@/src/api/loginAPI';
 
-interface IProp {}
+interface IProp { }
 
 interface IState {
   date: Date;

--- a/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
+++ b/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
@@ -1,6 +1,6 @@
 import './index.scss';
 
-import { qs, qsAll } from '@/src/utils/selecthelper';
+import { qs, qsAll } from '@/src/utils/selectHelper';
 import Component from '@/src/core/Component';
 import { CardType } from '@/src/interfaces/CardType';
 import { html } from '@/src/utils/codeHelper';
@@ -27,9 +27,9 @@ export default class CardTypeSelector extends Component<IState, IProps> {
         <div class="card-type-selector--toggle">선택</div>
         <ul class="card-type-selector--list">
           ${cardTypes &&
-          cardTypes
-            .map(
-              cardType => html`
+      cardTypes
+        .map(
+          cardType => html`
                 <li
                   data-card="${cardType.name}"
                   class="card-type-selector--list--item"
@@ -39,8 +39,8 @@ export default class CardTypeSelector extends Component<IState, IProps> {
                   <div>${cardType.color}</div>
                 </li>
               `
-            )
-            .join('')}
+        )
+        .join('')}
         </ul>
       </div>
     `;

--- a/client/src/components/LedgerAddModal/CategorySelector/index.ts
+++ b/client/src/components/LedgerAddModal/CategorySelector/index.ts
@@ -2,7 +2,7 @@ import './index.scss';
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
 import { ICategoryItem } from '@/src/interfaces/Category';
-import { qs, qsAll } from '@/src/utils/selecthelper';
+import { qs, qsAll } from '@/src/utils/selectHelper';
 
 interface IState {
   isShowCategories: boolean;
@@ -26,13 +26,13 @@ export default class CategorySelector extends Component<IState, IProps> {
         <div class="category-selector--toggle">선택</div>
         <ul class="category-selector--list">
           ${categories
-            ?.map(
-              (category: ICategoryItem) => /* html */ `
+        ?.map(
+          (category: ICategoryItem) => /* html */ `
                     <li class="category-selector--list--item ledger-category"
                     data-category="${category.name}" data-category-type="${category.id}">${category.name}</li>
                 `
-            )
-            .join('')}
+        )
+        .join('')}
         </ul>
       </div>
     `;

--- a/client/src/components/LedgerAddModal/index.ts
+++ b/client/src/components/LedgerAddModal/index.ts
@@ -1,6 +1,6 @@
 import './index.scss';
 import Component from '@/src/core/Component';
-import { qs } from '@/src/utils/selecthelper';
+import { qs } from '@/src/utils/selectHelper';
 import { html } from '@/src/utils/codeHelper';
 import CategorySelector from './CategorySelector';
 import CardTypeSelector from './CardTypeSelector';
@@ -33,7 +33,7 @@ interface IState {
   $dateInput: HTMLInputElement;
 }
 
-interface IProps {}
+interface IProps { }
 
 export default class LedgerAddModal extends Component<IState, IProps> {
   template() {

--- a/client/src/components/PaymentTypeAddModal/index.ts
+++ b/client/src/components/PaymentTypeAddModal/index.ts
@@ -2,7 +2,7 @@ import './index.scss';
 
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
-import { qs, qsAll } from '@/src/utils/selecthelper';
+import { qs, qsAll } from '@/src/utils/selectHelper';
 
 const backgroundColors = [
   '#6ed5eb',
@@ -25,7 +25,7 @@ interface IState {
   name: string;
 }
 
-interface IProps {}
+interface IProps { }
 
 export default class PaymentTypeAddModal extends Component<IState, IProps> {
   setup() {
@@ -52,28 +52,28 @@ export default class PaymentTypeAddModal extends Component<IState, IProps> {
           <div class="payment-type-modal--bg-section--label">배경색</div>
           <ul id="bg-color-picker" class="color-picker">
             ${backgroundColors
-              .map(
-                color => html`
+        .map(
+          color => html`
                   <li class="color-picker--item" data-color="${color}">
                     <div class="box" style="background-color:${color}"></div>
                   </li>
                 `
-              )
-              .join('')}
+        )
+        .join('')}
           </ul>
         </div>
         <div class="payment-type-modal--font-section">
           <div class="payment-type-modal--font-section--label">글자색</div>
           <ul id="font-color-picker" class="color-picker">
             ${fontColors
-              .map(
-                color => html`
+        .map(
+          color => html`
                   <li class="color-picker--item" data-color="${color}">
                     <div class="box" style="background-color:${color}"></div>
                   </li>
                 `
-              )
-              .join('')}
+        )
+        .join('')}
           </ul>
         </div>
         <div class="payment-type-modal--preview-section">

--- a/client/src/pages/StatisticPage/CategoryList/index.scss
+++ b/client/src/pages/StatisticPage/CategoryList/index.scss
@@ -20,7 +20,7 @@
           justify-content: center;
           align-content: center;
           border-radius: 3em;
-          background-color: blue;
+          background-color: transparent;
           color: $off-white;
           font-size: 0.85em;
           padding-top: 0.2em;

--- a/client/src/pages/StatisticPage/CategoryList/index.ts
+++ b/client/src/pages/StatisticPage/CategoryList/index.ts
@@ -2,12 +2,10 @@ import Component from "@/src/core/Component";
 import { html } from "@/src/utils/codeHelper";
 import "./index.scss";
 
-interface IState {
-
-}
+interface IState { }
 
 interface IProps {
-    items?: CategoryItem[]
+    items?: CategoryItem[],
 }
 
 export interface CategoryItem {
@@ -18,12 +16,12 @@ export interface CategoryItem {
 }
 
 export default class CategoryList extends Component<IState, IProps> {
-
     template() {
         const { items } = this.$props;
+        const totalCost = items ? items.reduce((acc, curr) => { return acc + curr.value }, 0) : 0;
         return html`
             <div class="category-container">
-                <h1 class="category-container--title">이번 달 지출 금액 843,000 </h1>
+                <h1 class="category-container--title">이번 달 지출 금액 ${totalCost} 원</h1>
                 <ul class="category-container--list">
                     ${items && items.map(item => html`
                         <li class="category-container--list--item">

--- a/client/src/pages/StatisticPage/CategoryList/index.ts
+++ b/client/src/pages/StatisticPage/CategoryList/index.ts
@@ -1,5 +1,5 @@
 import Component from "@/src/core/Component";
-import { html } from "@/src/utils/codeHelper";
+import { addComma, html } from "@/src/utils/codeHelper";
 import "./index.scss";
 
 interface IState { }
@@ -21,13 +21,13 @@ export default class CategoryList extends Component<IState, IProps> {
         const totalCost = items ? items.reduce((acc, curr) => { return acc + curr.value }, 0) : 0;
         return html`
             <div class="category-container">
-                <h1 class="category-container--title">이번 달 지출 금액 ${totalCost} 원</h1>
+                <h1 class="category-container--title">이번 달 지출 금액 ${addComma(totalCost)} 원</h1>
                 <ul class="category-container--list">
                     ${items && items.map(item => html`
                         <li class="category-container--list--item">
                             <div class="category" style="background-color:${item.color}"><span>${item.name}</span></div>
                             <div class="percentage">${item.percentage}%</div>
-                            <div class="cost">${item.value}원</div>
+                            <div class="cost">${addComma(item.value)}원</div>
                         </li>
                         `).join("")}
                 </ul>

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -27,6 +27,10 @@
     flex-shrink: 0;
     width: 300px;
     height: 300px;
+    > svg {
+      width: 100%;
+      height: 100%;
+    }
   }
 
   #statistic-category-container {
@@ -45,6 +49,10 @@
     @media (max-width: $tablet-max-width) {
       width: 400px;
       height: 250px;
+    }
+    > svg {
+      width: 100%;
+      height: 100%;
     }
   }
 }

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -42,6 +42,29 @@
 .sub-chart-container {
   display: flex;
   justify-content: center;
+  flex-direction: column;
+
+  &--header {
+    display: flex;
+    align-self: flex-end;
+    .reset-btn {
+      display: flex;
+      align-content: center;
+      flex-grow: 0;
+      border-radius: 8px;
+      background-color: $primary;
+      color: $off-white;
+      font-size: 0.85em;
+      padding: 0.4em;
+      border: 1px solid $primary;
+      &:hover {
+        color: $primary;
+        background-color: transparent;
+      }
+    }
+  }
+
+  
 
   #line-chart {
     width: 600px;

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -10,7 +10,7 @@ import { collapseTextChangeRangesAcrossMultipleVersions } from 'typescript';
 import { removeAllChildNode } from '@/src/utils/domHelper';
 
 interface IState {
-  rawData?: StatisticLedgerByCategory;
+  statisticData?: StatisticLedgerByCategory;
   categoryItems?: CategoryItem[];
 }
 interface IProps { }
@@ -24,6 +24,9 @@ export default class StatisticPage extends Component<IState, IProps> {
                 <div id="statistic-category-container"></div>
               </div>
               <div class="sub-chart-container">
+                <div class="sub-chart-container--header">
+                  <div id="reset-line-chart-btn" class="reset-btn">전체 데이터 보기</div>
+                </div>
                 <div id="line-chart"></div>
               </div>
             </div>
@@ -31,14 +34,14 @@ export default class StatisticPage extends Component<IState, IProps> {
   }
 
   setup() {
-    this.$state = { rawData: {} };
+    this.$state = { statisticData: {} };
 
     getStatisticLedgers().then(result => {
       if (result.success) {
         const statisticData = result.data;
 
         this.setState({
-          rawData: statisticData,
+          statisticData: statisticData,
           categoryItems: mapToCategoryItemData(statisticData)
         });
       }
@@ -47,21 +50,25 @@ export default class StatisticPage extends Component<IState, IProps> {
 
   mounted() {
     const { categoryItems } = this.$state;
-
     const $categoryList = qs("#statistic-category-container") as HTMLElement;
     new CategoryList($categoryList, { items: categoryItems });
+
+    const $lineChartResetBtn = qs("#reset-line-chart-btn") as HTMLElement;
+    $lineChartResetBtn.addEventListener("click", () => {
+      this.renderLineChartAllCategory();
+    });
 
     this.renderPieChart();
     this.renderLineChartAllCategory();
   }
 
   renderPieChart() {
-    const { rawData } = this.$state;
-    if (!rawData) {
-
+    const { statisticData } = this.$state;
+    const $pieChartContainer = document.querySelector('#pie-chart') as HTMLElement;
+    if (!statisticData) {
+      $pieChartContainer.innerHTML = html`<p>데이터가 없습니다.</p>`;
     } else {
-      const pieChartData = mapToPieChartData(rawData);
-      const $pieChartContainer = document.querySelector('#pie-chart') as HTMLElement;
+      const pieChartData = mapToPieChartData(statisticData);
       removeAllChildNode($pieChartContainer);
 
       const $pieChartSVG = document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
@@ -75,29 +82,29 @@ export default class StatisticPage extends Component<IState, IProps> {
   }
 
   renderLineChartAllCategory() {
-    const { rawData } = this.$state;
+    const { statisticData } = this.$state;
     const $lineChartContainer = document.querySelector('#line-chart') as HTMLElement;
     removeAllChildNode($lineChartContainer);
 
-    if (!rawData) {
+    if (!statisticData) {
       $lineChartContainer.innerHTML = html`<p>데이터가 없습니다.</p>`;
     } else {
-      const lineChartData = mapToLineChartData(rawData)
+      const lineChartData = mapToLineChartData(statisticData)
       this.renderLineChart(lineChartData);
     }
   }
 
   renderLineChartByCategory(category: string) {
-    const { rawData } = this.$state;
+    const { statisticData } = this.$state;
     const $lineChartContainer = document.querySelector('#line-chart') as HTMLElement;
     removeAllChildNode($lineChartContainer);
 
-    if (!rawData) {
+    if (!statisticData) {
       $lineChartContainer.innerHTML = html`<p>데이터가 없습니다.</p>`;
     } else {
       let categortAsKey: keyof StatisticLedgerByCategory = category;
       const filtered: StatisticLedgerByCategory = {
-        [category]: rawData[categortAsKey]
+        [category]: statisticData[categortAsKey]
       }
       const lineChartData = mapToLineChartData(filtered);
       this.renderLineChart(lineChartData);

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -11,7 +11,7 @@ import { removeAllChildNode } from '@/src/utils/domHelper';
 
 interface IState {
   statisticData?: StatisticLedgerByCategory;
-  categoryItems?: CategoryItem[];
+
 }
 interface IProps { }
 
@@ -42,24 +42,33 @@ export default class StatisticPage extends Component<IState, IProps> {
 
         this.setState({
           statisticData: statisticData,
-          categoryItems: mapToCategoryItemData(statisticData)
         });
       }
     });
   }
 
   mounted() {
-    const { categoryItems } = this.$state;
-    const $categoryList = qs("#statistic-category-container") as HTMLElement;
-    new CategoryList($categoryList, { items: categoryItems });
-
     const $lineChartResetBtn = qs("#reset-line-chart-btn") as HTMLElement;
     $lineChartResetBtn.addEventListener("click", () => {
       this.renderLineChartAllCategory();
     });
 
+    this.renderCategoryList();
     this.renderPieChart();
     this.renderLineChartAllCategory();
+  }
+
+  renderCategoryList() {
+    const { statisticData } = this.$state;
+    const $categoryList = qs("#statistic-category-container") as HTMLElement;
+
+    if (!statisticData) {
+      new CategoryList($categoryList, { items: [] });
+    } else {
+      const items = mapToCategoryItemData(statisticData);
+      new CategoryList($categoryList, { items });
+    }
+
   }
 
   renderPieChart() {

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -1,26 +1,17 @@
 import { getStatisticLedgers, StatisticLedgerByCategory } from '@/src/api/statisticAPI';
 import Component from '@/src/core/Component';
-import { qs } from "@/src/utils/selecthelper";
+import { qs } from "@/src/utils/selectHelper";
 import LineChart, { LineChartData, LineGroupChartData } from '@/src/utils/charts/LineChart';
 import PieChart, { PieChartData } from '@/src/utils/charts/PieChart';
 import CategoryList, { CategoryItem } from './CategoryList';
-
 import './index.scss';
-
-// TODO: Mocking Data
-const mockDataByCategory: PieChartData[] = [
-  { name: '카드', value: 10, color: 'Coral' },
-  { name: '현금', value: 50, color: '#00ab6b' },
-  { name: '적금', value: 30, color: '#00ab6b' },
-  { name: '적금', value: 30, color: '#00ab6b' },
-  { name: '적금', value: 30, color: '#00ab6b' },
-];
-
+import { html } from '@/src/utils/codeHelper';
+import { collapseTextChangeRangesAcrossMultipleVersions } from 'typescript';
+import { removeAllChildNode } from '@/src/utils/domHelper';
 
 interface IState {
-  pieChartData?: PieChartData[];
+  rawData?: StatisticLedgerByCategory;
   categoryItems?: CategoryItem[];
-  lineChartData?: LineGroupChartData;
 }
 interface IProps { }
 
@@ -29,99 +20,146 @@ export default class StatisticPage extends Component<IState, IProps> {
     return /* html */`
             <div class='statistic-container'>
               <div class="chart-container">
-                <svg id="pie-chart"></svg>
+                <div id="pie-chart"></div>
                 <div id="statistic-category-container"></div>
               </div>
               <div class="sub-chart-container">
-                <svg id="line-chart"></svg>
+                <div id="line-chart"></div>
               </div>
             </div>
           `;
   }
 
   setup() {
-    this.$state = { pieChartData: [], lineChartData: {} };
+    this.$state = { rawData: {} };
 
     getStatisticLedgers().then(result => {
       if (result.success) {
         const statisticData = result.data;
 
         this.setState({
-          pieChartData: this.mapToPieChartData(statisticData),
-          lineChartData: this.mapToLineChartData(statisticData),
-          categoryItems: this.mapToCategoryItemData(statisticData)
+          rawData: statisticData,
+          categoryItems: mapToCategoryItemData(statisticData)
         });
       }
     });
   }
 
   mounted() {
-    const { pieChartData, lineChartData, categoryItems } = this.$state;
+    const { categoryItems } = this.$state;
 
     const $categoryList = qs("#statistic-category-container") as HTMLElement;
     new CategoryList($categoryList, { items: categoryItems });
 
-    const $pieChart = document.querySelector('#pie-chart') as SVGElement;
-    PieChart.init($pieChart, pieChartData, {
-      onClick: (d: string) => {
-        // TODO: change line chart
-        console.log('click: ' + d);
-      },
+    this.renderPieChart();
+    this.renderLineChartAllCategory();
+  }
+
+  renderPieChart() {
+    const { rawData } = this.$state;
+    if (!rawData) {
+
+    } else {
+      const pieChartData = mapToPieChartData(rawData);
+      const $pieChartContainer = document.querySelector('#pie-chart') as HTMLElement;
+      removeAllChildNode($pieChartContainer);
+
+      const $pieChartSVG = document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
+      $pieChartContainer.appendChild($pieChartSVG);
+      PieChart.init($pieChartSVG, pieChartData, {
+        onClick: (name: string) => {
+          this.renderLineChartByCategory(name);
+        },
+      });
+    }
+  }
+
+  renderLineChartAllCategory() {
+    const { rawData } = this.$state;
+    const $lineChartContainer = document.querySelector('#line-chart') as HTMLElement;
+    removeAllChildNode($lineChartContainer);
+
+    if (!rawData) {
+      $lineChartContainer.innerHTML = html`<p>데이터가 없습니다.</p>`;
+    } else {
+      const lineChartData = mapToLineChartData(rawData)
+      this.renderLineChart(lineChartData);
+    }
+  }
+
+  renderLineChartByCategory(category: string) {
+    const { rawData } = this.$state;
+    const $lineChartContainer = document.querySelector('#line-chart') as HTMLElement;
+    removeAllChildNode($lineChartContainer);
+
+    if (!rawData) {
+      $lineChartContainer.innerHTML = html`<p>데이터가 없습니다.</p>`;
+    } else {
+      let categortAsKey: keyof StatisticLedgerByCategory = category;
+      const filtered: StatisticLedgerByCategory = {
+        [category]: rawData[categortAsKey]
+      }
+      const lineChartData = mapToLineChartData(filtered);
+      this.renderLineChart(lineChartData);
+    }
+  }
+
+  renderLineChart(lineChartData: LineGroupChartData) {
+    const $lineChartContainer = document.querySelector('#line-chart') as HTMLElement;
+    const $lineChartSVG = document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
+    LineChart.init($lineChartSVG, lineChartData);
+    $lineChartContainer.appendChild($lineChartSVG);
+  }
+}
+
+function mapToCategoryItemData(data: StatisticLedgerByCategory): CategoryItem[] {
+  const categoryItems: CategoryItem[] = [];
+  let totalOfAllCategory = 0;
+
+  for (const key in data) totalOfAllCategory += data[key].total
+
+  for (const [key, value] of Object.entries(data)) {
+    const { total, color } = value;
+    const percentage = totalOfAllCategory ? ((total / totalOfAllCategory) * 100).toFixed(1) : 0;
+    categoryItems.push({
+      name: key,
+      color: color,
+      percentage: Number(percentage),
+      value: total
     });
+  }
+  return categoryItems;
+}
 
-    const $lineChart = document.querySelector('#line-chart') as SVGElement;
-    LineChart.init($lineChart, lineChartData);
+function mapToPieChartData(data: StatisticLedgerByCategory): PieChartData[] {
+  const pieChartData: PieChartData[] = [];
+  for (const [key, value] of Object.entries(data)) {
+    const { total, color } = value;
+    pieChartData.push({
+      name: key,
+      value: total,
+      color: color,
+    });
+  }
+  return pieChartData;
+}
+
+function mapToLineChartData(data: StatisticLedgerByCategory): LineGroupChartData {
+  const lineGroupChartData: LineGroupChartData = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    const { color, entries } = value;
+    lineGroupChartData[key] = {
+      data: entries.map<LineChartData>(entry => {
+        return {
+          name: '',
+          datetime: entry.datetime,
+          value: entry.value,
+        };
+      }),
+      color,
+    };
   }
 
-  mapToCategoryItemData(data: StatisticLedgerByCategory): CategoryItem[] {
-    const categoryItems: CategoryItem[] = [];
-
-    let totalOfAllCategory = 0;
-
-    for (const key in data) totalOfAllCategory += data[key].total
-
-    for (const [key, value] of Object.entries(data)) {
-      const { total, color } = value;
-      const percentage = totalOfAllCategory ? ((total / totalOfAllCategory) * 100).toFixed(1) : 0;
-      categoryItems.push({
-        name: key,
-        color: color,
-        percentage: Number(percentage),
-        value: total
-      });
-    }
-    return categoryItems;
-  }
-  mapToPieChartData(data: StatisticLedgerByCategory): PieChartData[] {
-    const pieChartData: PieChartData[] = [];
-    for (const [key, value] of Object.entries(data)) {
-      const { total, color } = value;
-      pieChartData.push({
-        name: key,
-        value: total,
-        color: color,
-      });
-    }
-    return pieChartData;
-  }
-
-  mapToLineChartData(data: StatisticLedgerByCategory): LineGroupChartData {
-    const lineGroupChartData: LineGroupChartData = {};
-
-    for (const [key, value] of Object.entries(data)) {
-      const { color, entries } = value;
-      lineGroupChartData[key] = {
-        data: entries.map<LineChartData>(entry => {
-          return {
-            name: '',
-            datetime: entry.datetime,
-            value: entry.value,
-          };
-        }),
-        color,
-      };
-    }
-
-    return lineGroupChartData;
-  }
+  return lineGroupChartData;
 }

--- a/client/src/pages/WalletPage/index.ts
+++ b/client/src/pages/WalletPage/index.ts
@@ -1,7 +1,7 @@
 import './index.scss';
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
-import { qs, qsAll } from '@/src/utils/selecthelper';
+import { qs, qsAll } from '@/src/utils/selectHelper';
 import { getPaymentTypesAsync, PaymentType } from '@/src/api/paymentTypeAPI';
 import PaymentTypeAddModal from '@/src/components/PaymentTypeAddModal';
 
@@ -11,7 +11,7 @@ interface IState {
   $editButton?: HTMLElement;
 }
 
-interface IProps {}
+interface IProps { }
 
 const EDIT_MODE_ON_STRING = '수정 하기';
 const EDIT_MODE_OFF_STRING = '수정 중';

--- a/client/src/utils/domHelper.ts
+++ b/client/src/utils/domHelper.ts
@@ -1,0 +1,7 @@
+export const removeAllChildNode = (element: HTMLElement) => {
+    let parentNode = element;
+    while (parentNode.hasChildNodes()) {
+        const child = parentNode.firstChild;
+        if (child) parentNode.removeChild(child);
+    }
+}

--- a/client/src/utils/selecthelper.ts
+++ b/client/src/utils/selecthelper.ts
@@ -5,3 +5,4 @@ export const qs = (selector: string, target: HTMLElement | Document = document) 
 export const qsAll = (selector: string, target: HTMLElement | Document = document) => {
   return target.querySelectorAll(selector);
 };
+


### PR DESCRIPTION
## 개요

Pie Chart 클릭시 특정 카테고리만 Line 차트로 그리는 작업 추가

Pie 차트 클릭시 해당 카테고리만 아래 Line Chart에 그려지게 됩니다. 그리고 다시 전체 데이터를 보고 싶다면 
전체 데이터 보기 버튼을 클릭하면 다시 라인차트가 전체 데이터를 그리게 됩니다.

## 변경사항

## 참고사항

통계 데이터를 위한 API 구현과 통계데이터에 적용

## 추가 구현 필요사항

카테고리 리스트를 눌렀을 때도 동일하게 처리해야합니다.
그리고 서버에서 보내주는 API 설계와 API를 받았을 때 date를 Date타입으로 전처리해줘야했습니다.

## 스크린샷
![Aug-03-2021 17-22-29](https://user-images.githubusercontent.com/20085849/127983001-4504192d-2195-4837-b30f-e9df0bbc4eae.gif)



