### PR TITLE
[#74] 가계부 추가 기능 완성(API 통합 및 Frontend 부족한 부분완성)

### DIFF
--- a/client/src/api/categoryAPI.ts
+++ b/client/src/api/categoryAPI.ts
@@ -1,0 +1,6 @@
+import { Category } from "../interfaces/Category";
+import { getFetch, Result } from "./fetch";
+
+export const getCategoriesAsync = async (): Promise<Result<Category[]>> => {
+    return await getFetch("/category");
+};

--- a/client/src/api/fetch.ts
+++ b/client/src/api/fetch.ts
@@ -4,6 +4,12 @@ interface IApiFetch {
   body?: BodyInit | undefined | null;
 }
 
+
+export interface Result<D> {
+  success: boolean;
+  data: D;
+}
+
 const setQuery = (query: object) => {
   let _query = '?';
   for (const [key, value] of Object.entries(query)) {

--- a/client/src/api/ledgerAPI.ts
+++ b/client/src/api/ledgerAPI.ts
@@ -1,9 +1,5 @@
 import { ILedger, ILedgerList } from '../interfaces/Ledger';
-import { getFetch } from './fetch';
-interface Result<D> {
-  success: boolean;
-  data: D;
-}
+import { getFetch, Result } from './fetch';
 
 export interface LedgerType {
   numDate: string;

--- a/client/src/api/ledgerAPI.ts
+++ b/client/src/api/ledgerAPI.ts
@@ -1,5 +1,5 @@
 import { ILedger, ILedgerList } from '../interfaces/Ledger';
-import { getFetch, Result } from './fetch';
+import { getFetch, postFetch, Result } from './fetch';
 
 export interface LedgerType {
   numDate: string;
@@ -16,3 +16,28 @@ export const getLedgerData = (date: string): Promise<Result<ILedgerList[]>> =>
       "Content-Type": 'application/json',
     }
   });
+
+interface CreateLedgerResult {
+  id: number
+}
+
+export const createLedgerData = async (
+  date: string,
+  paymentTypeId: number,
+  categoryId: number,
+  amount: number,
+  content: string): Promise<Result<CreateLedgerResult>> => {
+
+  return postFetch("/ledger/", {
+    headers: {
+      "Content-Type": 'application/json',
+    },
+    body: JSON.stringify({
+      date,
+      paymentTypeId,
+      categoryId,
+      amount,
+      content
+    })
+  })
+}

--- a/client/src/api/paymentTypeAPI.ts
+++ b/client/src/api/paymentTypeAPI.ts
@@ -1,20 +1,5 @@
-import { deleteFetch, getFetch, postFetch } from "./fetch";
-
-interface Result<D> {
-  success: boolean;
-  data: D;
-}
-
-export interface PaymentType {
-  id: number;
-  accountId: number;
-  name: string;
-  bgColor: string;
-  fontColor: string;
-  createAt: Date;
-  updateAt: Date;
-  image: string;
-}
+import { PaymentType } from "../interfaces/PaymentType";
+import { deleteFetch, getFetch, postFetch, Result } from "./fetch";
 
 
 export const getOwnPaymentTypesAsync = async (): Promise<Result<PaymentType[]>> => {

--- a/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
+++ b/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
@@ -3,7 +3,8 @@ import './index.scss';
 import { qs, qsAll } from '@/src/utils/selectHelper';
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
-import { getOwnPaymentTypesAsync, PaymentType } from '@/src/api/paymentTypeAPI';
+import { getOwnPaymentTypesAsync } from '@/src/api/paymentTypeAPI';
+import { PaymentType } from '@/src/interfaces/PaymentType';
 
 interface IState {
   isShowCardTypes: boolean;
@@ -21,10 +22,14 @@ export default class CardTypeSelector extends Component<IState, IProps> {
       isShowCardTypes: false,
     };
     getOwnPaymentTypesAsync().then(({ success, data }) => {
-      this.setState({
-        ...this.$state,
-        paymentTypes: data,
-      })
+      if (success) {
+        this.setState({
+          ...this.$state,
+          paymentTypes: data,
+        })
+      } else {
+        console.error("결제수단을 가져오는데 실패했습니다.");
+      }
     })
   }
 

--- a/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
+++ b/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
@@ -12,7 +12,7 @@ interface IState {
 }
 
 interface IProps {
-  onClickCard: (value: string) => void;
+  onClickCard: (id: number, value: string) => void;
 }
 
 export default class CardTypeSelector extends Component<IState, IProps> {
@@ -44,7 +44,7 @@ export default class CardTypeSelector extends Component<IState, IProps> {
         .map(
           paymentType => html`
                 <li
-                  data-card="${paymentType.name}"
+                  data-id="${paymentType.id}"
                   class="card-type-selector--list--item"
                   style="background-color:${paymentType.bgColor};color:${paymentType.fontColor}"
                 >
@@ -82,11 +82,15 @@ export default class CardTypeSelector extends Component<IState, IProps> {
     const itemElements = qsAll('.card-type-selector--list--item', this.$target);
     for (const itemElement of Array.from(itemElements)) {
       if (target === itemElement) {
-        const { card } = target.dataset;
-        if (card) {
-          onClickCard(card);
-          this.toggleCardTypeList(false);
+        const { id } = target.dataset;
+        const idAsNumber = Number(id);
+        if (!isNaN(idAsNumber)) {
+          const paymentType = this.$state.paymentTypes.find(paymentType => paymentType.id === idAsNumber);
+          if (paymentType) {
+            onClickCard(idAsNumber, paymentType.name);
+          }
         }
+        this.toggleCardTypeList(false);
       }
     }
   }

--- a/client/src/components/LedgerAddModal/CategorySelector/index.ts
+++ b/client/src/components/LedgerAddModal/CategorySelector/index.ts
@@ -11,7 +11,7 @@ interface IState {
 }
 
 interface IProps {
-  onClickCategory: (value: string) => void;
+  onClickCategory: (id: number, name: string) => void;
 }
 
 export default class CategorySelector extends Component<IState, IProps> {
@@ -35,8 +35,8 @@ export default class CategorySelector extends Component<IState, IProps> {
           ${categories
         ?.map(
           (category: Category) => /* html */ `
-                    <li class="category-selector--list--item ledger-category"
-                    data-category="${category.name}" data-category-type="${category.id}">${category.name}</li>
+                    <li class="category-selector--list--item ledger-category" style="background-color:${category.color}"
+                    data-id="${category.id}">${category.name}</li>
                 `
         )
         .join('')}
@@ -70,11 +70,15 @@ export default class CategorySelector extends Component<IState, IProps> {
     const itemElements = qsAll('.category-selector--list--item', this.$target);
     for (const itemElement of Array.from(itemElements)) {
       if (target === itemElement) {
-        const { category } = target.dataset;
-        if (category) {
-          onClickCategory(category);
-          this.toggleCategoryList(false);
+        const { id } = target.dataset;
+        const idAsNumber = Number(id);
+        if (!isNaN(idAsNumber)) {
+          const category = this.$state.categories.find(category => category.id === idAsNumber);
+          if (category) {
+            onClickCategory(idAsNumber, category.name);
+          }
         }
+        this.toggleCategoryList(false);
       }
     }
   }

--- a/client/src/components/LedgerAddModal/CategorySelector/index.ts
+++ b/client/src/components/LedgerAddModal/CategorySelector/index.ts
@@ -1,33 +1,40 @@
 import './index.scss';
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
-import { ICategoryItem } from '@/src/interfaces/Category';
+import { Category } from '@/src/interfaces/Category';
 import { qs, qsAll } from '@/src/utils/selectHelper';
+import { getCategoriesAsync } from '@/src/api/categoryAPI';
 
 interface IState {
   isShowCategories: boolean;
+  categories: Category[];
 }
 
 interface IProps {
-  categories: ICategoryItem[];
   onClickCategory: (value: string) => void;
 }
 
 export default class CategorySelector extends Component<IState, IProps> {
   setup() {
-    this.$state = { isShowCategories: false };
+    this.$state = { isShowCategories: false, categories: [] };
+
+    getCategoriesAsync().then(({ success, data }) => {
+      if (success) {
+        this.setState({ ...this.$state, categories: data });
+      }
+    })
   }
 
   // TODO: property를 통해서 category list 와 색깔 정보를 얻어와야합니다.
   template() {
-    const { categories } = this.$props;
+    const { categories } = this.$state;
     return html`
       <div class="category-selector">
         <div class="category-selector--toggle">선택</div>
         <ul class="category-selector--list">
           ${categories
         ?.map(
-          (category: ICategoryItem) => /* html */ `
+          (category: Category) => /* html */ `
                     <li class="category-selector--list--item ledger-category"
                     data-category="${category.name}" data-category-type="${category.id}">${category.name}</li>
                 `

--- a/client/src/components/LedgerAddModal/index.ts
+++ b/client/src/components/LedgerAddModal/index.ts
@@ -5,7 +5,7 @@ import { html } from '@/src/utils/codeHelper';
 import CategorySelector from './CategorySelector';
 import CardTypeSelector from './CardTypeSelector';
 import Snackbar from '../SnackBar';
-import { PaymentType } from '@/src/api/paymentTypeAPI';
+import { PaymentType } from '@/src/interfaces/PaymentType';
 
 const mockCategories = [
   { id: 1, name: '취미' },
@@ -92,8 +92,7 @@ export default class LedgerAddModal extends Component<IState, IProps> {
 
     const $categorySelectorElement = qs('#category-selector-container', this.$target) as HTMLElement;
     new CategorySelector($categorySelectorElement, {
-      categories: mockCategories,
-      onClickCategory: (category: string) => this.handleSelectCategory(category),
+      onClickCategory: (category: string) => this.handleSelectCategory(category)
     });
 
     const $cardTypeSelectorElement = qs('#card-type-selector-container', this.$target) as HTMLElement;

--- a/client/src/components/LedgerAddModal/index.ts
+++ b/client/src/components/LedgerAddModal/index.ts
@@ -5,6 +5,8 @@ import { html } from '@/src/utils/codeHelper';
 import CategorySelector from './CategorySelector';
 import CardTypeSelector from './CardTypeSelector';
 import Snackbar from '../SnackBar';
+import { createLedgerData, getLedgerData } from '@/src/api/ledgerAPI';
+import calendarModel from '@/src/models/Calendar';
 
 interface Error {
   [key: string]: string;
@@ -14,7 +16,7 @@ interface IState {
   $amountInput: HTMLInputElement;
   $categoryInput: HTMLInputElement;
   $contentInput: HTMLInputElement;
-  $cardTypeInput: HTMLInputElement;
+  $paymentTypeInput: HTMLInputElement;
   $dateInput: HTMLInputElement;
 
   paymentTypeId: number;
@@ -52,7 +54,7 @@ export default class LedgerAddModal extends Component<IState, IProps> {
         <span class="spliter"></span>
         <div class="ledger-modal-container--input-box">
           <label for="amount-input">금액</label>
-          <input id="amount-input" type="text" placeholder="입력하세요" />
+          <input id="amount-input" type="number" min="1" step="any" placeholder="입력하세요" />
         </div>
         <span class="spliter"></span>
         <div class="ledger-modal-container--submit-box">
@@ -68,7 +70,7 @@ export default class LedgerAddModal extends Component<IState, IProps> {
     this.$state.$amountInput = qs('#amount-input', this.$target) as HTMLInputElement;
     this.$state.$categoryInput = qs('#category-input', this.$target) as HTMLInputElement;
     this.$state.$contentInput = qs('#content-input', this.$target) as HTMLInputElement;
-    this.$state.$cardTypeInput = qs('#card-type-input', this.$target) as HTMLInputElement;
+    this.$state.$paymentTypeInput = qs('#card-type-input', this.$target) as HTMLInputElement;
     this.$state.$dateInput = qs('#date-input', this.$target) as HTMLInputElement;
 
     const $categorySelectorElement = qs('#category-selector-container', this.$target) as HTMLElement;
@@ -90,10 +92,6 @@ export default class LedgerAddModal extends Component<IState, IProps> {
     const $submitBtnElement = qs('.submit-btn', this.$target) as HTMLElement;
     $submitBtnElement.addEventListener('click', () => {
       const result = this.submit();
-      if (result) {
-        this.clear();
-        this.hide();
-      }
     });
 
     const $cancelBtnElement = this.$target.querySelector('.cancel-btn') as HTMLElement;
@@ -109,13 +107,24 @@ export default class LedgerAddModal extends Component<IState, IProps> {
   }
 
   handleSelectPaymentType(id: number, name: string) {
-    this.$state.$cardTypeInput.value = name;
+    this.$state.$paymentTypeInput.value = name;
     this.$state.paymentTypeId = id;
   }
 
   handleSelectCategory(id: number, name: string) {
     this.$state.$categoryInput.value = name;
     this.$state.categoryId = id;
+  }
+
+  async createLedgerAsync(date: Date, paymentTypeId: number, categoryId: number, amount: number, content: string) {
+    const yearAndMonth = `${date.getFullYear()}-${date.getMonth() + 1}`;
+
+    const { success, data: { id } } = await createLedgerData(yearAndMonth, paymentTypeId, categoryId, amount, content);
+    if (success) {
+      this.clear();
+      this.hide();
+      calendarModel.setDate(calendarModel.getDate()); // for refresh main page;
+    }
   }
 
   submit() {
@@ -128,18 +137,25 @@ export default class LedgerAddModal extends Component<IState, IProps> {
       return false;
     }
 
+    const { $amountInput, $contentInput, $dateInput, categoryId, paymentTypeId } = this.$state;
+
+    const date = new Date($dateInput.value);
+    const amount = Number($amountInput.value);
+    const content = $contentInput.value;
+
+    this.createLedgerAsync(date, paymentTypeId, categoryId, amount, content);
     return true;
   }
 
   validateForm(): Error {
-    const { $amountInput, $categoryInput, $contentInput, $cardTypeInput, $dateInput } = this.$state;
+    const { $amountInput, $categoryInput, $contentInput, $paymentTypeInput, $dateInput, categoryId, paymentTypeId } = this.$state;
     const error: Error = {};
 
     if (!$dateInput.value) {
       error.date = '날짜를 입력해주세요.';
     }
 
-    if (!$categoryInput.value) {
+    if (!$categoryInput.value || !categoryId) {
       error.category = '분류를 선택해주세요.';
     }
 
@@ -147,7 +163,7 @@ export default class LedgerAddModal extends Component<IState, IProps> {
       error.content = '내용을 입력해주세요.';
     }
 
-    if (!$cardTypeInput.value) {
+    if (!$paymentTypeInput.value || !paymentTypeId) {
       error.cardType = '결제 수단을 선택해주세요.';
     }
 
@@ -159,11 +175,11 @@ export default class LedgerAddModal extends Component<IState, IProps> {
   }
 
   clear() {
-    const { $amountInput, $categoryInput, $contentInput, $cardTypeInput, $dateInput } = this.$state;
+    const { $amountInput, $categoryInput, $contentInput, $paymentTypeInput, $dateInput } = this.$state;
     $amountInput.value = '';
     $categoryInput.value = '';
     $contentInput.value = '';
-    $cardTypeInput.value = '';
+    $paymentTypeInput.value = '';
     $dateInput.value = '';
   }
 

--- a/client/src/components/LedgerAddModal/index.ts
+++ b/client/src/components/LedgerAddModal/index.ts
@@ -5,22 +5,6 @@ import { html } from '@/src/utils/codeHelper';
 import CategorySelector from './CategorySelector';
 import CardTypeSelector from './CardTypeSelector';
 import Snackbar from '../SnackBar';
-import { PaymentType } from '@/src/interfaces/PaymentType';
-
-const mockCategories = [
-  { id: 1, name: '취미' },
-  { id: 2, name: '월급' },
-  { id: 3, name: '적금' },
-  { id: 4, name: '예금' },
-  { id: 5, name: '비상금' },
-  { id: 6, name: '보험비' },
-  { id: 6, name: '보험비' },
-  { id: 6, name: '보험비' },
-  { id: 6, name: '보험비' },
-  { id: 6, name: '보험비' },
-  { id: 6, name: '보험비' },
-  { id: 6, name: '보험비' },
-];
 
 interface Error {
   [key: string]: string;
@@ -32,8 +16,9 @@ interface IState {
   $contentInput: HTMLInputElement;
   $cardTypeInput: HTMLInputElement;
   $dateInput: HTMLInputElement;
-  paymentTypes: PaymentType[];
 
+  paymentTypeId: number;
+  categoryId: number;
 }
 
 interface IProps { }
@@ -78,10 +63,6 @@ export default class LedgerAddModal extends Component<IState, IProps> {
     `;
   }
 
-  setup() {
-    this.$state.paymentTypes = [];
-
-  }
 
   mounted() {
     this.$state.$amountInput = qs('#amount-input', this.$target) as HTMLInputElement;
@@ -92,13 +73,13 @@ export default class LedgerAddModal extends Component<IState, IProps> {
 
     const $categorySelectorElement = qs('#category-selector-container', this.$target) as HTMLElement;
     new CategorySelector($categorySelectorElement, {
-      onClickCategory: (category: string) => this.handleSelectCategory(category)
+      onClickCategory: (id, name: string) => this.handleSelectCategory(id, name)
     });
 
     const $cardTypeSelectorElement = qs('#card-type-selector-container', this.$target) as HTMLElement;
     new CardTypeSelector($cardTypeSelectorElement, {
-      onClickCard: (card: string) => {
-        this.handleSelectCardType(card);
+      onClickCard: (id: number, name: string) => {
+        this.handleSelectPaymentType(id, name);
       },
     });
 
@@ -127,12 +108,14 @@ export default class LedgerAddModal extends Component<IState, IProps> {
     });
   }
 
-  handleSelectCardType(card: string) {
-    this.$state.$cardTypeInput.value = card;
+  handleSelectPaymentType(id: number, name: string) {
+    this.$state.$cardTypeInput.value = name;
+    this.$state.paymentTypeId = id;
   }
 
-  handleSelectCategory(category: string) {
-    this.$state.$categoryInput.value = category;
+  handleSelectCategory(id: number, name: string) {
+    this.$state.$categoryInput.value = name;
+    this.$state.categoryId = id;
   }
 
   submit() {

--- a/client/src/interfaces/Category.ts
+++ b/client/src/interfaces/Category.ts
@@ -1,4 +1,5 @@
-export interface ICategoryItem {
+export interface Category {
   id: number;
   name: string;
+  color: string;
 }

--- a/client/src/interfaces/PaymentType.ts
+++ b/client/src/interfaces/PaymentType.ts
@@ -1,0 +1,11 @@
+
+export interface PaymentType {
+    id: number;
+    accountId: number;
+    name: string;
+    bgColor: string;
+    fontColor: string;
+    createAt: Date;
+    updateAt: Date;
+    image: string;
+}

--- a/client/src/models/PaymentTypeList.ts
+++ b/client/src/models/PaymentTypeList.ts
@@ -1,4 +1,5 @@
-import { PaymentType } from '../api/paymentTypeAPI';
+
+import { PaymentType } from '../interfaces/PaymentType';
 import Observer from './Observer';
 
 export class PaymentTypeListModel extends Observer {

--- a/client/src/pages/WalletPage/index.ts
+++ b/client/src/pages/WalletPage/index.ts
@@ -2,9 +2,10 @@ import './index.scss';
 import Component from '@/src/core/Component';
 import { html } from '@/src/utils/codeHelper';
 import { qs, qsAll } from '@/src/utils/selectHelper';
-import { deleteOwnPaymentTypeAsync, getOwnPaymentTypesAsync, PaymentType } from '@/src/api/paymentTypeAPI';
+import { deleteOwnPaymentTypeAsync, getOwnPaymentTypesAsync } from '@/src/api/paymentTypeAPI';
 import PaymentTypeAddModal from '@/src/components/PaymentTypeAddModal';
 import paymentTypeListModel from '@/src/models/PaymentTypeList';
+import { PaymentType } from '@/src/interfaces/PaymentType';
 
 interface IState {
   paymentTypes: PaymentType[];

--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -107,19 +107,18 @@ class LedgerController {
 
     if (newLedgerId) {
       res.send({
-        succuss: true,
+        success: true,
         data: { id: newLedgerId }
       }).end();
     } else {
       res.status(SERVER_ERROR).send({
-        succuss: false,
+        success: false,
         error: ERROR_CREATION_LEDGER_FAIL
       }).end();
     }
   }
 
   // TODO: 수정, 삭제 API 추가.
-
 
 }
 


### PR DESCRIPTION
## 개요

가계부를 추가 모달을 개발했던 REST API(카테고리 가져오기, 유저의 결제수단가져오기, Ledger 생성하기) 와 연동했습니다.

## 변경사항

- 여러 타입들 경로 정리 ( 범용적으로 사용되는 interface는 `/src/interfaces` 로 이동)

## 참고사항

## 추가 구현 필요사항

아직 Input 들을 제대로 검증하지못했습니다.
예외처리를 위해 QA를 추가적으로 해볼 필요가 있습니다.

## 스크린샷
