### PR TITLE
한달 데이터를 다채워서 보내주도록 통계 Ledger API 수정 및 다양한 Issue 해결

### DIFF
--- a/client/src/api/ledgerAPI.ts
+++ b/client/src/api/ledgerAPI.ts
@@ -12,13 +12,14 @@ export interface LedgerType {
 
 export const getLedgerData = (date: string): Promise<Result<ILedgerList[]>> =>
   getFetch('/ledger/day', {
-    query: { date }, headers: {
-      "Content-Type": 'application/json',
-    }
+    query: { date },
+    headers: {
+      'Content-Type': 'application/json',
+    },
   });
 
 interface CreateLedgerResult {
-  id: number
+  id: number;
 }
 
 export const createLedgerData = async (
@@ -26,18 +27,18 @@ export const createLedgerData = async (
   paymentTypeId: number,
   categoryId: number,
   amount: number,
-  content: string): Promise<Result<CreateLedgerResult>> => {
-
-  return postFetch("/ledger/", {
+  content: string
+): Promise<Result<CreateLedgerResult>> => {
+  return postFetch('/ledger/', {
     headers: {
-      "Content-Type": 'application/json',
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       date,
       paymentTypeId,
       categoryId,
       amount,
-      content
-    })
-  })
-}
+      content,
+    }),
+  });
+};

--- a/client/src/api/paymentTypeAPI.ts
+++ b/client/src/api/paymentTypeAPI.ts
@@ -1,25 +1,27 @@
-import { PaymentType } from "../interfaces/PaymentType";
-import { deleteFetch, getFetch, postFetch, Result } from "./fetch";
-
+import { PaymentType } from '../interfaces/PaymentType';
+import { deleteFetch, getFetch, postFetch, Result } from './fetch';
 
 export const getOwnPaymentTypesAsync = async (): Promise<Result<PaymentType[]>> => {
-  return await getFetch("/paymentType");
+  return await getFetch('/paymentType');
 };
 
 export const deleteOwnPaymentTypeAsync = async (id: number): Promise<Result<any>> => {
   return await deleteFetch(`/paymentType/${id}`, { headers: { contentType: 'application/json' } });
-}
+};
 
-export const createPaymentTypeAsync = async (name: string, bgColor: string, fontColor: string): Promise<Result<number>> => {
-
+export const createPaymentTypeAsync = async (
+  name: string,
+  bgColor: string,
+  fontColor: string
+): Promise<Result<number>> => {
   return await postFetch(`/paymentType`, {
     headers: {
-      "Content-Type": 'application/json',
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       name,
       bgColor,
-      fontColor
-    })
+      fontColor,
+    }),
   });
-}
+};

--- a/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
+++ b/client/src/components/LedgerAddModal/CardTypeSelector/index.ts
@@ -17,23 +17,6 @@ interface IProps {
 }
 
 export default class CardTypeSelector extends Component<IState, IProps> {
-  setup() {
-    this.$state = {
-      paymentTypes: [],
-      isShowCardTypes: false,
-    };
-    getOwnPaymentTypesAsync().then(({ success, data }) => {
-      if (success) {
-        this.setState({
-          ...this.$state,
-          paymentTypes: data,
-        });
-      } else {
-        console.error('결제수단을 가져오는데 실패했습니다.');
-      }
-    });
-  }
-
   template() {
     const { paymentTypes } = this.$state;
     return html`
@@ -57,6 +40,30 @@ export default class CardTypeSelector extends Component<IState, IProps> {
         </ul>
       </div>
     `;
+  }
+  setup() {
+    this.$state = {
+      paymentTypes: [],
+      isShowCardTypes: false,
+    };
+    this.fetchOwnPaymentTypes();
+  }
+
+  async fetchOwnPaymentTypes() {
+    try {
+      const { success, data } = await getOwnPaymentTypesAsync();
+      if (success) {
+        this.setState({
+          ...this.$state,
+          paymentTypes: data,
+        });
+      } else {
+        console.error('결제수단을 가져오는데 실패했습니다.');
+      }
+    } catch (err) {
+      // only Unauthorized Error.
+      console.error(err);
+    }
   }
 
   mounted() {

--- a/client/src/components/LedgerAddModal/index.ts
+++ b/client/src/components/LedgerAddModal/index.ts
@@ -1,7 +1,7 @@
 import './index.scss';
 import Component from '@/src/core/Component';
 import { qs } from '@/src/utils/selectHelper';
-import { addComma, html } from '@/src/utils/codeHelper';
+import { addComma, convertToYYYYMMDD, html } from '@/src/utils/codeHelper';
 import CategorySelector from './CategorySelector';
 import CardTypeSelector from './CardTypeSelector';
 import Snackbar from '../SnackBar';
@@ -134,12 +134,9 @@ export default class LedgerAddModal extends Component<IState, IProps> {
   }
 
   async createLedgerAsync(date: Date, paymentTypeId: number, categoryId: number, amount: number, content: string) {
-    const yearAndMonth = `${date.getFullYear()}-${date.getMonth() + 1}`;
+    const formatedDate = convertToYYYYMMDD(date);
 
-    const {
-      success,
-      data: { id },
-    } = await createLedgerData(yearAndMonth, paymentTypeId, categoryId, amount, content);
+    const { success } = await createLedgerData(formatedDate, paymentTypeId, categoryId, amount, content);
     if (success) {
       this.clear();
       this.hide();

--- a/client/src/components/LoginModal/index.scss
+++ b/client/src/components/LoginModal/index.scss
@@ -31,8 +31,7 @@
     align-items: center;
     justify-content: center;
     box-shadow: 0 0 23px var(--line-color);
-    animation: loginShow 1.5s ease-in-out 1 forwards;
-
+    animation: loginShow 1s ease-in-out 0.5s forwards;
     @media (max-width: $phone-max-width) {
       height: 100%;
       border-radius: 0;

--- a/client/src/components/LoginModal/index.scss
+++ b/client/src/components/LoginModal/index.scss
@@ -10,7 +10,7 @@
   }
   100% {
     bottom: 50%;
-    transform: translate(-50%, 50%) ㄴcaleX(100%) scaleY(100%);
+    transform: translate(-50%, 50%) scaleX(100%) scaleY(100%);
   }
 }
 

--- a/client/src/components/LoginModal/index.scss
+++ b/client/src/components/LoginModal/index.scss
@@ -10,7 +10,7 @@
   }
   100% {
     bottom: 50%;
-    transform: stranslate(-50%, 50%) caleX(100%) scaleY(100%);
+    transform: translate(-50%, 50%) ㄴcaleX(100%) scaleY(100%);
   }
 }
 

--- a/client/src/components/LoginModal/index.scss
+++ b/client/src/components/LoginModal/index.scss
@@ -3,14 +3,14 @@
 @keyframes loginShow {
   0% {
     bottom: -200%;
-    transform: translate(-50%, -50%) scaleY(0);
+    transform: translate(-50%, 50%) scaleY(0);
   }
   50% {
-    transform: translate(-50%, -50%) scaleX(0);
+    transform: translate(-50%, 50%) scaleX(0);
   }
   100% {
     bottom: 50%;
-    transform: translate(-50%, -50%) scaleX(100%) scaleY(100%);
+    transform: stranslate(-50%, 50%) caleX(100%) scaleY(100%);
   }
 }
 

--- a/client/src/models/Ledgers.ts
+++ b/client/src/models/Ledgers.ts
@@ -38,7 +38,9 @@ export class LedgerDataModel extends Observer {
   }
   async update(date: string) {
     //TODO LEDGERS DATA UPDATE
+    console.log(date);
     const newLedgerData = (await getLedgerData(date)).data;
+    console.log(newLedgerData);
     this.setData(newLedgerData);
   }
 }

--- a/client/src/models/Ledgers.ts
+++ b/client/src/models/Ledgers.ts
@@ -37,10 +37,7 @@ export class LedgerDataModel extends Observer {
     this.notify();
   }
   async update(date: string) {
-    //TODO LEDGERS DATA UPDATE
-    console.log(date);
     const newLedgerData = (await getLedgerData(date)).data;
-    console.log(newLedgerData);
     this.setData(newLedgerData);
   }
 }

--- a/client/src/pages/CalendarPage/index.ts
+++ b/client/src/pages/CalendarPage/index.ts
@@ -14,8 +14,16 @@ interface IProps {}
 const CALENDAR_OBSERVER_LISTENER_KEY = 'calendar';
 export default class CalendarPages extends Component<IState, IProps> {
   setup() {
-    this.$state.ledgerData = LedgerDataModel.getData();
-    this.$state.date = CalendarModel.getDate();
+    this.$state = {
+      ledgerData: [],
+      date: CalendarModel.getDate(),
+    };
+    this.fetchInitLedgers();
+  }
+
+  async fetchInitLedgers() {
+    await LedgerDataModel.update(converToYYYYMM(CalendarModel.getDate()));
+    this.setState({ ledgerData: LedgerDataModel.getData(), date: CalendarModel.getDate() });
   }
 
   template() {

--- a/client/src/pages/CalendarPage/index.ts
+++ b/client/src/pages/CalendarPage/index.ts
@@ -3,6 +3,7 @@ import Component from '@/src/core/Component';
 import { ILedgerList } from '@/src/interfaces/Ledger';
 import CalendarModel from '@/src/models/Calendar';
 import LedgerDataModel from '@/src/models/Ledgers';
+import { converToYYYYMM } from '@/src/utils/codeHelper';
 import './index.scss';
 
 interface IState {
@@ -34,8 +35,8 @@ export default class CalendarPages extends Component<IState, IProps> {
   async CalendarModelSubscribeFunction() {
     const target = this.$target.querySelector('.calendar-wrapper') as HTMLElement;
     const date = CalendarModel.getDate();
-    await LedgerDataModel.update(date.getFullYear() + '-' + (date.getMonth() + 1));
-    new Calendar(target, { ledgerData: LedgerDataModel.getData(), date: CalendarModel.getDate() });
+    await LedgerDataModel.update(converToYYYYMM(date));
+    new Calendar(target, { ledgerData: LedgerDataModel.getData(), date });
   }
 
   setEvent() {

--- a/client/src/pages/MainPage/index.ts
+++ b/client/src/pages/MainPage/index.ts
@@ -7,7 +7,7 @@ import './index.scss';
 import LedgerDataModel from '@/src/models/Ledgers';
 import CalendarModel from '@/src/models/Calendar';
 import { ILedgerList } from '@/src/interfaces/Ledger';
-import { html } from '@/src/utils/codeHelper';
+import { converToYYYYMM, html } from '@/src/utils/codeHelper';
 import Snackbar from '@/src/components/SnackBar';
 
 interface IState {}
@@ -19,8 +19,7 @@ const CALENDAR_OBSERVER_LISTENER_KEY = 'main';
 export default class MainPage extends Component<IProps, IState> {
   setup() {
     this.$state.ledgerData = LedgerDataModel.getData();
-    const calendarDate = CalendarModel.getDate();
-    LedgerDataModel.update(calendarDate.getFullYear() + '-' + (calendarDate.getMonth() + 1));
+    LedgerDataModel.update(converToYYYYMM(CalendarModel.getDate()));
   }
 
   template() {
@@ -47,10 +46,9 @@ export default class MainPage extends Component<IProps, IState> {
   }
 
   async CalendarModelSubscribeFunction() {
-    console.log('Calendar Subscribe!');
     const body = this.$target.querySelector('#body') as HTMLElement;
-    const calendarDate = CalendarModel.getDate();
-    await LedgerDataModel.update(calendarDate.getFullYear() + '-' + (calendarDate.getMonth() + 1));
+
+    await LedgerDataModel.update(converToYYYYMM(CalendarModel.getDate()));
 
     const ledgerData = LedgerDataModel.getData();
 
@@ -60,9 +58,11 @@ export default class MainPage extends Component<IProps, IState> {
 
     new LedgerContainer(body, { ledgerData });
   }
+
   setUnmount() {
     CalendarModel.unsubscribe(CALENDAR_OBSERVER_LISTENER_KEY);
   }
+
   setEvent() {
     CalendarModel.subscribe(CALENDAR_OBSERVER_LISTENER_KEY, this.CalendarModelSubscribeFunction.bind(this));
     this.resetEvent();

--- a/client/src/pages/MainPage/index.ts
+++ b/client/src/pages/MainPage/index.ts
@@ -19,7 +19,10 @@ const CALENDAR_OBSERVER_LISTENER_KEY = 'main';
 export default class MainPage extends Component<IProps, IState> {
   setup() {
     this.$state.ledgerData = LedgerDataModel.getData();
+    const calendarDate = CalendarModel.getDate();
+    LedgerDataModel.update(calendarDate.getFullYear() + '-' + (calendarDate.getMonth() + 1));
   }
+
   template() {
     return html`
       <div id="body"></div>
@@ -44,6 +47,7 @@ export default class MainPage extends Component<IProps, IState> {
   }
 
   async CalendarModelSubscribeFunction() {
+    console.log('Calendar Subscribe!');
     const body = this.$target.querySelector('#body') as HTMLElement;
     const calendarDate = CalendarModel.getDate();
     await LedgerDataModel.update(calendarDate.getFullYear() + '-' + (calendarDate.getMonth() + 1));
@@ -52,7 +56,6 @@ export default class MainPage extends Component<IProps, IState> {
 
     if (!ledgerData?.length) {
       new Snackbar(document.body, { text: '앗 ! 데이터가 없어요 !' });
-      return;
     }
 
     new LedgerContainer(body, { ledgerData });

--- a/client/src/pages/MainPage/index.ts
+++ b/client/src/pages/MainPage/index.ts
@@ -18,8 +18,12 @@ interface IProps {
 const CALENDAR_OBSERVER_LISTENER_KEY = 'main';
 export default class MainPage extends Component<IProps, IState> {
   setup() {
-    this.$state.ledgerData = LedgerDataModel.getData();
-    LedgerDataModel.update(converToYYYYMM(CalendarModel.getDate()));
+    this.fetchInitLedgers();
+  }
+
+  async fetchInitLedgers() {
+    await LedgerDataModel.update(converToYYYYMM(CalendarModel.getDate()));
+    this.setState({ ledgerData: LedgerDataModel.getData() });
   }
 
   template() {
@@ -46,16 +50,14 @@ export default class MainPage extends Component<IProps, IState> {
   }
 
   async CalendarModelSubscribeFunction() {
-    const body = this.$target.querySelector('#body') as HTMLElement;
-
     await LedgerDataModel.update(converToYYYYMM(CalendarModel.getDate()));
 
     const ledgerData = LedgerDataModel.getData();
 
+    const body = this.$target.querySelector('#body') as HTMLElement;
     if (!ledgerData?.length) {
       new Snackbar(document.body, { text: '앗 ! 데이터가 없어요 !' });
     }
-
     new LedgerContainer(body, { ledgerData });
   }
 

--- a/client/src/pages/StatisticPage/CategoryList/index.scss
+++ b/client/src/pages/StatisticPage/CategoryList/index.scss
@@ -1,39 +1,46 @@
 @import '../../../global.scss';
 
 .category-container {
-    align-self: flex-start;
-    &--title {
-      font-size: 2em;
-    }
+  align-self: flex-start;
+  &--title {
+    font-size: 2em;
+  }
 
-    &--list {
-      padding: 0px;
-      margin-top: 35px;
-      &--item {
-        display: grid;
-        padding: 1em 0;
-        grid-template-columns: 5em 1fr 0.5fr;
-        grid-column-gap: 0.5em;
-        align-items: center;
-        & > .category {
-          display: flex;
-          justify-content: center;
-          align-content: center;
-          border-radius: 3em;
-          background-color: transparent;
-          color: $off-white;
-          font-size: 0.85em;
-          padding-top: 0.2em;
-          padding-bottom: 0.2em;
-        }
-        & > .percent {
-          flex-grow: 1;
-          border:1px solid red;
-        }
-        & > .cost {
-          text-align: end;
-          flex-grow: 1;
-        }
+  &--list {
+    padding: 0px;
+    margin-top: 35px;
+    &--item {
+      display: grid;
+      padding: 1em 0;
+      grid-template-columns: 5em 1fr 0.5fr;
+      grid-column-gap: 0.5em;
+      align-items: center;
+      & > .category {
+        display: flex;
+        justify-content: center;
+        align-content: center;
+        border-radius: 3em;
+        background-color: transparent;
+        color: $off-white;
+        font-size: 0.85em;
+        padding-top: 0.2em;
+        padding-bottom: 0.2em;
+      }
+      & > .percent {
+        flex-grow: 1;
+        border: 1px solid red;
+      }
+      & > .cost {
+        text-align: end;
+        flex-grow: 1;
+      }
+      & > * {
+        pointer-events: none;
+        user-select: none;
+      }
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.2);
       }
     }
   }
+}

--- a/client/src/pages/StatisticPage/CategoryList/index.ts
+++ b/client/src/pages/StatisticPage/CategoryList/index.ts
@@ -1,37 +1,69 @@
-import Component from "@/src/core/Component";
-import { addComma, html } from "@/src/utils/codeHelper";
-import "./index.scss";
+import Component from '@/src/core/Component';
+import { addComma, html } from '@/src/utils/codeHelper';
+import { qs, qsAll } from '@/src/utils/selectHelper';
+import './index.scss';
 
-interface IState { }
+interface IState {}
 
 interface IProps {
-    items?: CategoryItem[],
+  items?: CategoryItem[];
+  onClickItem: (name: string) => void;
 }
 
 export interface CategoryItem {
-    name: string,
-    percentage: number,
-    value: number,
-    color: string
+  name: string;
+  percentage: number;
+  value: number;
+  color: string;
 }
 
 export default class CategoryList extends Component<IState, IProps> {
-    template() {
-        const { items } = this.$props;
-        const totalCost = items ? items.reduce((acc, curr) => { return acc + curr.value }, 0) : 0;
-        return html`
-            <div class="category-container">
-                <h1 class="category-container--title">이번 달 지출 금액 ${addComma(totalCost)} 원</h1>
-                <ul class="category-container--list">
-                    ${items && items.map(item => html`
-                        <li class="category-container--list--item">
-                            <div class="category" style="background-color:${item.color}"><span>${item.name}</span></div>
-                            <div class="percentage">${item.percentage}%</div>
-                            <div class="cost">${addComma(item.value)}원</div>
-                        </li>
-                        `).join("")}
-                </ul>
-            </div>
-        `;
-    }
+  template() {
+    const { items } = this.$props;
+    const totalCost = items
+      ? items.reduce((acc, curr) => {
+          return acc + curr.value;
+        }, 0)
+      : 0;
+    return html`
+      <div class="category-container">
+        <h1 class="category-container--title">이번 달 지출 금액 ${addComma(totalCost)} 원</h1>
+        <ul class="category-container--list">
+          ${items &&
+          items
+            .map(
+              item => html`
+                <li class="category-container--list--item" data-name="${item.name}">
+                  <div class="category" style="background-color:${item.color}"><span>${item.name}</span></div>
+                  <div class="percentage">${item.percentage}%</div>
+                  <div class="cost">${addComma(item.value)}원</div>
+                </li>
+              `
+            )
+            .join('')}
+        </ul>
+      </div>
+    `;
+  }
+
+  mounted() {
+    const $categoryItemList = qs('.category-container--list', this.$target) as HTMLElement;
+    $categoryItemList.addEventListener('click', e => {
+      const target = e.target as HTMLElement;
+      const categoryItems = qsAll('.category-container--list--item', $categoryItemList);
+
+      for (const $categoryItem of categoryItems) {
+        if ($categoryItem === target) {
+          const { name } = target.dataset;
+          if (name) {
+            this.handleClickCategoryItem(name);
+          }
+        }
+      }
+    });
+  }
+
+  handleClickCategoryItem(name: string) {
+    this.$props.onClickItem(name);
+  }
 }

--- a/client/src/pages/StatisticPage/CategoryList/index.ts
+++ b/client/src/pages/StatisticPage/CategoryList/index.ts
@@ -6,11 +6,11 @@ import './index.scss';
 interface IState {}
 
 interface IProps {
-  items?: CategoryItem[];
+  items?: CategoryListItem[];
   onClickItem: (name: string) => void;
 }
 
-export interface CategoryItem {
+export interface CategoryListItem {
   name: string;
   percentage: number;
   value: number;

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -1,13 +1,14 @@
-import { getStatisticLedgers, StatisticLedgerByCategory } from '@/src/api/statisticAPI';
+import './index.scss';
 import Component from '@/src/core/Component';
 import { qs } from '@/src/utils/selectHelper';
 import { html } from '@/src/utils/codeHelper';
-import LineChart, { LineChartData, LineGroupChartData } from '@/src/utils/charts/LineChart';
 import PieChart, { PieChartData } from '@/src/utils/charts/PieChart';
-import CategoryList, { CategoryItem } from './CategoryList';
-import { removeAllChildNode } from '@/src/utils/domHelper';
-import './index.scss';
+import CategoryList, { CategoryListItem } from './CategoryList';
+
 import calendarDataModel from '@/src/models/Calendar';
+import LineChart, { LineChartData, LineGroupChartData } from '@/src/utils/charts/LineChart';
+import { removeAllChildNode } from '@/src/utils/domHelper';
+import { getStatisticLedgers, StatisticLedgerByCategory } from '@/src/api/statisticAPI';
 
 const CALENDAR_OBSERVER_LISTENER_KEY = 'statistic';
 
@@ -146,8 +147,8 @@ export default class StatisticPage extends Component<IState, IProps> {
   }
 }
 
-function mapToCategoryItemData(data: StatisticLedgerByCategory): CategoryItem[] {
-  const categoryItems: CategoryItem[] = [];
+function mapToCategoryItemData(data: StatisticLedgerByCategory): CategoryListItem[] {
+  const categoryItems: CategoryListItem[] = [];
   let totalOfAllCategory = 0;
 
   for (const key in data) totalOfAllCategory += data[key].total;

--- a/client/src/pages/StatisticPage/index.ts
+++ b/client/src/pages/StatisticPage/index.ts
@@ -1,6 +1,6 @@
 import { getStatisticLedgers, StatisticLedgerByCategory } from '@/src/api/statisticAPI';
 import Component from '@/src/core/Component';
-import { qs } from "@/src/utils/selectHelper";
+import { qs } from '@/src/utils/selectHelper';
 import { html } from '@/src/utils/codeHelper';
 import LineChart, { LineChartData, LineGroupChartData } from '@/src/utils/charts/LineChart';
 import PieChart, { PieChartData } from '@/src/utils/charts/PieChart';
@@ -9,24 +9,20 @@ import { removeAllChildNode } from '@/src/utils/domHelper';
 import './index.scss';
 import calendarDataModel from '@/src/models/Calendar';
 
-const CALENDAR_OBSERVER_LISTENER_KEY = "statistic"
+const CALENDAR_OBSERVER_LISTENER_KEY = 'statistic';
 
 interface IState {
   statisticData?: StatisticLedgerByCategory;
-
 }
-interface IProps { }
+interface IProps {}
 
 export default class StatisticPage extends Component<IState, IProps> {
   template() {
     const { statisticData } = this.$state;
-    return /* html */`
+    return /* html */ `
             <div class='statistic-container'>
               <div class="chart-container">
-                ${!statisticData || Object.keys(statisticData).length === 0
-        ? html`
-                  <h1>데이터가 없습니다.</h1>
-                  ` : ""}
+                ${!statisticData || Object.keys(statisticData).length === 0 ? html` <h1>데이터가 없습니다.</h1> ` : ''}
                 <div id="pie-chart"></div>
                 <div id="statistic-category-container"></div>
               </div>
@@ -56,8 +52,8 @@ export default class StatisticPage extends Component<IState, IProps> {
   }
 
   mounted() {
-    const $lineChartResetBtn = qs("#reset-line-chart-btn") as HTMLElement;
-    $lineChartResetBtn.addEventListener("click", () => {
+    const $lineChartResetBtn = qs('#reset-line-chart-btn') as HTMLElement;
+    $lineChartResetBtn.addEventListener('click', () => {
       this.renderLineChartAllCategory();
     });
 
@@ -68,14 +64,15 @@ export default class StatisticPage extends Component<IState, IProps> {
 
   renderCategoryList() {
     const { statisticData } = this.$state;
-    const $categoryList = qs("#statistic-category-container") as HTMLElement;
+    const $categoryList = qs('#statistic-category-container') as HTMLElement;
+    const items = statisticData ? mapToCategoryItemData(statisticData) : [];
 
-    if (!statisticData) {
-      new CategoryList($categoryList, { items: [] });
-    } else {
-      const items = mapToCategoryItemData(statisticData);
-      new CategoryList($categoryList, { items });
-    }
+    new CategoryList($categoryList, {
+      items,
+      onClickItem: (category: string) => {
+        this.renderLineChartByCategory(category);
+      },
+    });
   }
 
   renderPieChart() {
@@ -84,7 +81,7 @@ export default class StatisticPage extends Component<IState, IProps> {
     if (statisticData) {
       const pieChartData = mapToPieChartData(statisticData);
       removeAllChildNode($pieChartContainer);
-      const $pieChartSVG = document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
+      const $pieChartSVG = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGElement;
       $pieChartContainer.appendChild($pieChartSVG);
       PieChart.init($pieChartSVG, pieChartData, {
         onClick: (name: string) => {
@@ -100,7 +97,7 @@ export default class StatisticPage extends Component<IState, IProps> {
     removeAllChildNode($lineChartContainer);
 
     if (statisticData) {
-      const lineChartData = mapToLineChartData(statisticData)
+      const lineChartData = mapToLineChartData(statisticData);
       this.renderLineChart(lineChartData);
     }
   }
@@ -113,8 +110,8 @@ export default class StatisticPage extends Component<IState, IProps> {
     if (statisticData) {
       let categortAsKey: keyof StatisticLedgerByCategory = category;
       const filtered: StatisticLedgerByCategory = {
-        [category]: statisticData[categortAsKey]
-      }
+        [category]: statisticData[categortAsKey],
+      };
       const lineChartData = mapToLineChartData(filtered);
       this.renderLineChart(lineChartData);
     }
@@ -122,7 +119,7 @@ export default class StatisticPage extends Component<IState, IProps> {
 
   renderLineChart(lineChartData: LineGroupChartData) {
     const $lineChartContainer = document.querySelector('#line-chart') as HTMLElement;
-    const $lineChartSVG = document.createElementNS("http://www.w3.org/2000/svg", "svg") as SVGElement;
+    const $lineChartSVG = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGElement;
     LineChart.init($lineChartSVG, lineChartData);
     $lineChartContainer.appendChild($lineChartSVG);
   }
@@ -147,14 +144,13 @@ export default class StatisticPage extends Component<IState, IProps> {
     calendarDataModel.subscribe(CALENDAR_OBSERVER_LISTENER_KEY, this.CalendarModelSubscribeFunction.bind(this));
     this.resetEvent();
   }
-
 }
 
 function mapToCategoryItemData(data: StatisticLedgerByCategory): CategoryItem[] {
   const categoryItems: CategoryItem[] = [];
   let totalOfAllCategory = 0;
 
-  for (const key in data) totalOfAllCategory += data[key].total
+  for (const key in data) totalOfAllCategory += data[key].total;
 
   for (const [key, value] of Object.entries(data)) {
     const { total, color } = value;
@@ -163,7 +159,7 @@ function mapToCategoryItemData(data: StatisticLedgerByCategory): CategoryItem[] 
       name: key,
       color: color,
       percentage,
-      value: total
+      value: total,
     });
   }
   return categoryItems;

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -35,6 +35,7 @@ export interface LineChartOptions {
   yLabelFontSize?: string;
   lineOpacity?: number;
   lineWidth?: number;
+  showGrid?: boolean;
 }
 
 const defaultOptions: LineChartOptions = {
@@ -43,6 +44,7 @@ const defaultOptions: LineChartOptions = {
   yLabelFontSize: '1em',
   lineOpacity: 0.5,
   lineWidth: 3,
+  showGrid: false,
   formatXLabel: null,
 };
 
@@ -170,8 +172,10 @@ export default class LineChart {
   }
 
   renderAxisGrid(items: ProcessedLineChartData[]) {
-    this.renderXAxisGrid(items);
-    this.renderYAxisGrid(items);
+    if (this.options.showGrid) {
+      this.renderXAxisGrid(items);
+      this.renderYAxisGrid(items);
+    }
   }
 
   renderXAxisGrid(items: ProcessedLineChartData[]) {

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -46,7 +46,7 @@ const defaultOptions: LineChartOptions = {
   formatXLabel: null,
 };
 
-const LEFT_POS = 80;
+const LEFT_POS = 100;
 const TOP_POS = 50;
 const BOTTOM_POS = 420;
 const RIGHT_POS = 750;
@@ -163,7 +163,7 @@ export default class LineChart {
       Object.entries(this.groupData).map(([key, entry]) => {
         this.renderAxisGrid(entry.data);
         this.renderLines(entry.data, entry.color);
-        this.renderPoints(entry.data, key);
+        this.renderPoints(entry.data, entry.color);
         this.renderLabels(entry.data);
       });
     }
@@ -215,7 +215,7 @@ export default class LineChart {
     this.element.appendChild(yAsixGrid);
   }
 
-  renderPoints(items: ProcessedLineChartData[], category: string) {
+  renderPoints(items: ProcessedLineChartData[], color = '#000000') {
     if (!(this.scaleX && this.scaleY)) {
       throw new Error('Scale Function is undefined.');
     }
@@ -227,7 +227,8 @@ export default class LineChart {
         const y = this.scaleY(item.value);
         const point = svgCircle(x, y, 6);
         point.setAttribute('data-value', item.name);
-        point.setAttribute('opacity', '0.2');
+        point.setAttribute('fill', color);
+        point.setAttribute('opacity', '0.4');
         point.addEventListener('mouseover', () => {
           point.style.opacity = '1';
           point.style.transition = `transform 0.2s 0s ease`;

--- a/client/src/utils/charts/LineChart.ts
+++ b/client/src/utils/charts/LineChart.ts
@@ -43,6 +43,7 @@ const defaultOptions: LineChartOptions = {
   yLabelFontSize: '1em',
   lineOpacity: 0.5,
   lineWidth: 3,
+  formatXLabel: null,
 };
 
 const LEFT_POS = 80;
@@ -138,7 +139,6 @@ export default class LineChart {
       this.minValueOfYAxis = Math.min(...values);
 
       this.scaleX = transformer().domain(this.minValueOfXAxis, this.maxValueOfXAxis).range(this.left, this.right);
-
       this.scaleY = transformer().domain(this.minValueOfYAxis, this.maxValueOfYAxis).range(this.bottom, this.top);
     }
   }
@@ -266,7 +266,7 @@ export default class LineChart {
     }
 
     // const $path = svgLinePath(points.reverse());
-    const $path = svgCurveLinePath(points.reverse());
+    const $path = svgLinePath(points.reverse());
 
     // Line의 총 길이 구하기
     const l = $path.getTotalLength();
@@ -303,7 +303,11 @@ export default class LineChart {
       for (const d of items) {
         const x = this.scaleX(d.milliseconds);
         // TODO: Add option callback function formating label;
-        const label = d.datetime.getMonth() + '/' + d.datetime.getDate();
+
+        let label = d.datetime.getDate().toString();
+        if (this.options.formatXLabel) {
+          label = this.options.formatXLabel(d.datetime);
+        }
         const text = svgText(x, this.bottom + this.xLabelPadding, label);
         text.setAttribute('text-anchor', 'middle');
         text.setAttribute('font-size', this.options.xLabelFontSize || '');

--- a/client/src/utils/codeHelper.ts
+++ b/client/src/utils/codeHelper.ts
@@ -13,3 +13,10 @@ export const convertToYYYYMMDD = (date: Date) => {
 
   return [date.getFullYear(), (mm > 9 ? '' : '0') + mm, (dd > 9 ? '' : '0') + dd].join('-');
 };
+
+export const converToYYYYMM = (date: Date) => {
+  var mm = date.getMonth() + 1; // getMonth() is zero-based
+  var dd = date.getDate();
+
+  return [date.getFullYear(), (mm > 9 ? '' : '0') + mm].join('-');
+};

--- a/client/src/utils/codeHelper.ts
+++ b/client/src/utils/codeHelper.ts
@@ -6,3 +6,10 @@ export const html = (str: TemplateStringsArray, ...args: unknown[]) =>
   str.map((s, i) => `${s}${args[i] || ''}`).join('');
 
 export const addComma = (n: number) => n.toLocaleString('ko-KR');
+
+export const convertToYYYYMMDD = (date: Date) => {
+  var mm = date.getMonth() + 1; // getMonth() is zero-based
+  var dd = date.getDate();
+
+  return [date.getFullYear(), (mm > 9 ? '' : '0') + mm, (dd > 9 ? '' : '0') + dd].join('-');
+};

--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -51,8 +51,8 @@ class LedgerController {
     const userIdAsNumber = Number(req.user.id);
 
     const { paymentTypeId, categoryId, date, content, amount } = req.body;
-
     const paymentTypeIdAsNumber = Number(paymentTypeId);
+    console.log(date);
     if (isNaN(paymentTypeIdAsNumber)) {
       res
         .status(BAD_REQUEST)

--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -4,9 +4,9 @@ import { LedgerRequestDTO, LedgerResponseDTO } from '../dto/LedgerDTO';
 import LedgerService from '../services/ledger.service';
 import categoryService from '../services/category.service';
 
-const ERROR_PARAMETER_INVALID = "입력 값이 잘못되었습니다.";
-const ERROR_CATEGORY_NOT_FOUND = "카테고리를 찾을 수 없습니다.";
-const ERROR_CREATION_LEDGER_FAIL = "가계부 데이터를 생성하는데 실패했습니다.";
+const ERROR_PARAMETER_INVALID = '입력 값이 잘못되었습니다.';
+const ERROR_CATEGORY_NOT_FOUND = '카테고리를 찾을 수 없습니다.';
+const ERROR_CREATION_LEDGER_FAIL = '가계부 데이터를 생성하는데 실패했습니다.';
 
 class LedgerController {
   async getLedgersByDate(req: Request, res: Response) {
@@ -38,11 +38,11 @@ class LedgerController {
     const date = new Date(queryDate);
     const userId = req.user.id!;
     const ledgers: LedgerResponseDTO[] = await LedgerService.getLedgersByMonth(date, userId);
-    const statisticLedgers = LedgerService.convertToStatisticLedgers(ledgers);
+    const statisticLedgers = LedgerService.convertToStatisticLedgers(ledgers, date);
 
     res.send({
       success: true,
-      data: statisticLedgers
+      data: statisticLedgers,
     });
   }
 
@@ -50,19 +50,16 @@ class LedgerController {
     // Assert User Id is valid.
     const userIdAsNumber = Number(req.user.id);
 
-    const {
-      paymentTypeId,
-      categoryId,
-      date,
-      content,
-      amount,
-    } = req.body;
+    const { paymentTypeId, categoryId, date, content, amount } = req.body;
 
     const paymentTypeIdAsNumber = Number(paymentTypeId);
     if (isNaN(paymentTypeIdAsNumber)) {
-      res.status(BAD_REQUEST).send({
-        error: ERROR_PARAMETER_INVALID + "(paymentType id is empty or invalid)"
-      }).end();
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(paymentType id is empty or invalid)',
+        })
+        .end();
       return;
     }
 
@@ -72,26 +69,35 @@ class LedgerController {
     const categoryIdAsNumber = Number(categoryId);
 
     if (isNaN(categoryIdAsNumber)) {
-      res.status(BAD_REQUEST).send({
-        error: ERROR_PARAMETER_INVALID + "(category id is empty or invalid)"
-      }).end();
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(category id is empty or invalid)',
+        })
+        .end();
       return;
     }
 
     const category = await categoryService.getCategory(categoryIdAsNumber);
     if (!category) {
-      res.status(BAD_REQUEST).send({
-        error: ERROR_CATEGORY_NOT_FOUND + `(id:${categoryIdAsNumber}).`
-      }).end();
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_CATEGORY_NOT_FOUND + `(id:${categoryIdAsNumber}).`,
+        })
+        .end();
       return;
     }
 
     const amountAsNumber = Number(amount);
 
     if (isNaN(amountAsNumber)) {
-      res.status(BAD_REQUEST).send({
-        error: ERROR_PARAMETER_INVALID + "(amount is invalid)"
-      }).end();
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(amount is invalid)',
+        })
+        .end();
       return;
     }
 
@@ -106,20 +112,24 @@ class LedgerController {
     const newLedgerId = await LedgerService.createLedger(ledgerDto, userIdAsNumber);
 
     if (newLedgerId) {
-      res.send({
-        success: true,
-        data: { id: newLedgerId }
-      }).end();
+      res
+        .send({
+          success: true,
+          data: { id: newLedgerId },
+        })
+        .end();
     } else {
-      res.status(SERVER_ERROR).send({
-        success: false,
-        error: ERROR_CREATION_LEDGER_FAIL
-      }).end();
+      res
+        .status(SERVER_ERROR)
+        .send({
+          success: false,
+          error: ERROR_CREATION_LEDGER_FAIL,
+        })
+        .end();
     }
   }
 
   // TODO: 수정, 삭제 API 추가.
-
 }
 
 export default new LedgerController();

--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -52,7 +52,7 @@ class LedgerController {
 
     const { paymentTypeId, categoryId, date, content, amount } = req.body;
     const paymentTypeIdAsNumber = Number(paymentTypeId);
-    console.log(date);
+
     if (isNaN(paymentTypeIdAsNumber)) {
       res
         .status(BAD_REQUEST)

--- a/server/src/controllers/paymentType.controller.ts
+++ b/server/src/controllers/paymentType.controller.ts
@@ -1,104 +1,114 @@
 import { Request, Response } from 'express';
 import { BAD_REQUEST, NOT_FOUND, SERVER_ERROR, SUCCESS, UNAUTHORIZED } from '../utils/HttpStatus';
-import paymentTypeService from "../services/paymentType.service";
+import paymentTypeService from '../services/paymentType.service';
 import { PaymentTypeRequestDTO } from '../dto/PaymentTypeDTO';
 
-
-const ERROR_RETRIEVE_USER_PAYMENTS_FAIL = "사용자의 결제 수단을 가져오는데 실패했습니다.";
-const ERROR_CREATE_USER_PAYMENTS_FAIL = "사용자의 결제 수단을 가져오는데 실패했습니다.";
-const ERROR_DELETE_USER_PAYMENTS_FAIL = "사용자의 결제 수단을 삭제하는데 실패했습니다.";
-const ERROR_PARAMETER_INVALID = "입력 값이 잘못되었습니다.";
+const ERROR_RETRIEVE_USER_PAYMENTS_FAIL = '사용자의 결제 수단을 가져오는데 실패했습니다.';
+const ERROR_CREATE_USER_PAYMENTS_FAIL = '사용자의 결제 수단을 가져오는데 실패했습니다.';
+const ERROR_DELETE_USER_PAYMENTS_FAIL = '사용자의 결제 수단을 삭제하는데 실패했습니다.';
+const ERROR_PARAMETER_INVALID = '입력 값이 잘못되었습니다.';
 
 class PaymentTypeController {
-    async createPaymentType(req: Request, res: Response) {
-        // Assert User Id is valid.
-        const userIdAsNumber = Number(req.user.id);
+  async createPaymentType(req: Request, res: Response) {
+    // Assert User Id is valid.
+    const userIdAsNumber = Number(req.user.id);
 
-        const {
-            name,
-            bgColor,
-            fontColor,
-        } = req.body;
-        console.log(name);
-        if (!name || name === "") {
-            res.status(BAD_REQUEST).send({
-                error: ERROR_PARAMETER_INVALID + "(name is empty or invalid.)"
-            }).end();
-            return;
-        }
+    const { name, bgColor, fontColor } = req.body;
 
-        const paymentType: PaymentTypeRequestDTO = {
-            name,
-            bgColor,
-            fontColor
-        };
-
-        // TODO: bgColor, fontColor format ("#ffffff") 체크필요.
-        const paymentTypeId = await paymentTypeService.createPaymentType(paymentType, userIdAsNumber);
-
-        if (paymentTypeId) {
-            res.status(SUCCESS).send({
-                success: true,
-                data: paymentTypeId
-            })
-        } else {
-            res.status(SERVER_ERROR).send({
-                success: false,
-                error: ERROR_CREATE_USER_PAYMENTS_FAIL
-            })
-        }
+    if (!name || name === '') {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(name is empty or invalid.)',
+        })
+        .end();
+      return;
     }
 
-    async getOwnPaymentTypes(req: Request, res: Response) {
-        const userIdAsNumber = Number(req.user.id);
-        try {
-            const paymentTypes = await paymentTypeService.getOwnPaymentTypes(userIdAsNumber);
-            res.status(SUCCESS).send({
-                success: true,
-                data: paymentTypes
-            });
-        } catch (error) {
-            console.log(error); // TODO: change to logger
-            res.status(SERVER_ERROR).send({
-                error: ERROR_RETRIEVE_USER_PAYMENTS_FAIL
-            })
-        }
+    const paymentType: PaymentTypeRequestDTO = {
+      name,
+      bgColor,
+      fontColor,
+    };
+
+    // TODO: bgColor, fontColor format ("#ffffff") 체크필요.
+    const paymentTypeId = await paymentTypeService.createPaymentType(paymentType, userIdAsNumber);
+
+    if (paymentTypeId) {
+      res.status(SUCCESS).send({
+        success: true,
+        data: paymentTypeId,
+      });
+    } else {
+      res.status(SERVER_ERROR).send({
+        success: false,
+        error: ERROR_CREATE_USER_PAYMENTS_FAIL,
+      });
+    }
+  }
+
+  async getOwnPaymentTypes(req: Request, res: Response) {
+    const userIdAsNumber = Number(req.user.id);
+    try {
+      const paymentTypes = await paymentTypeService.getOwnPaymentTypes(userIdAsNumber);
+      res.status(SUCCESS).send({
+        success: true,
+        data: paymentTypes,
+      });
+    } catch (error) {
+      console.log(error); // TODO: change to logger
+      res.status(SERVER_ERROR).send({
+        error: ERROR_RETRIEVE_USER_PAYMENTS_FAIL,
+      });
+    }
+  }
+
+  async deletePaymentType(req: Request, res: Response) {
+    const { id } = req.params;
+
+    const paymentIdAsNumber = Number(id);
+    if (isNaN(paymentIdAsNumber)) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + `(${id} is empty or invalid)`,
+        })
+        .end();
+      return;
     }
 
-    async deletePaymentType(req: Request, res: Response) {
-        const { id } = req.params;
+    const userIdAsNumber = Number(req.user.id);
 
-        const paymentIdAsNumber = Number(id);
-        if (isNaN(paymentIdAsNumber)) {
-            res.status(BAD_REQUEST).send({
-                error: ERROR_PARAMETER_INVALID + `(${id} is empty or invalid)`
-            }).end();
-            return;
-        }
-
-        const userIdAsNumber = Number(req.user.id);
-
-        try {
-            const isOwn = await paymentTypeService.isOwnPaymentType(paymentIdAsNumber, userIdAsNumber);
-            if (!isOwn) {
-                res.status(UNAUTHORIZED).send({
-                    error: ERROR_DELETE_USER_PAYMENTS_FAIL
-                }).end();
-                return;
-            }
-        } catch (error) {
-            res.status(BAD_REQUEST).send({
-                error: ERROR_DELETE_USER_PAYMENTS_FAIL + " " + error
-            }).end();
-            return;
-        }
-
-        const isDelete = await paymentTypeService.deletePaymentType(paymentIdAsNumber);
-        res.status(SUCCESS).send({
-            success: isDelete,
-        }).end();
+    try {
+      const isOwn = await paymentTypeService.isOwnPaymentType(paymentIdAsNumber, userIdAsNumber);
+      if (!isOwn) {
+        res
+          .status(UNAUTHORIZED)
+          .send({
+            error: ERROR_DELETE_USER_PAYMENTS_FAIL,
+          })
+          .end();
+        return;
+      }
+    } catch (error) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_DELETE_USER_PAYMENTS_FAIL + ' ' + error,
+        })
+        .end();
+      return;
     }
+
+    const isDelete = await paymentTypeService.deletePaymentType(paymentIdAsNumber);
+    res
+      .status(SUCCESS)
+      .send({
+        success: isDelete,
+      })
+      .end();
+  }
 }
 
-const paymentTypeController = new PaymentTypeController()
+const paymentTypeController = new PaymentTypeController();
 export default paymentTypeController;

--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -2,14 +2,14 @@ import { Request, Response, NextFunction } from 'express';
 import { UsersAttributes } from '../models/user.model';
 import UserRepository from '../repositories/user.repository';
 import JwtService from '../services/jwt.service';
-
+import { UNAUTHORIZED } from '../utils/HttpStatus';
 
 const ERROR_USER_IS_NOT_EXIST = '현재 토큰을 가진 유저가 없습니다.';
-const ERROR_ALL_TOKEN_IS_EXPIRED = "모든 토큰의 유효기간이 지났습니다.";
-const ERROR_HEADER_COOKIE_IS_NOT_EXIST = "해더에 쿠기가 존재하지않습니다.";
+const ERROR_ALL_TOKEN_IS_EXPIRED = '모든 토큰의 유효기간이 지났습니다.';
+const ERROR_HEADER_COOKIE_IS_NOT_EXIST = '헤더에 쿠키가 존재하지않습니다.';
 
 const ErrorJWT = (res: Response, message: string) => {
-  res.status(401).send({ success: false, message }).end();
+  res.status(UNAUTHORIZED).send({ success: false, message }).end();
 };
 
 const authJWT = async (req: Request, res: Response, next: NextFunction) => {

--- a/server/src/utils/arrayHelper.ts
+++ b/server/src/utils/arrayHelper.ts
@@ -1,0 +1,1 @@
+export const range = (n: number) => [...Array(n).keys()];

--- a/server/src/utils/dayHelper.ts
+++ b/server/src/utils/dayHelper.ts
@@ -1,0 +1,3 @@
+export const days = (month: number, year: number) => {
+  return new Date(year, month, 0).getDate();
+};


### PR DESCRIPTION


- [Bug] 알맞은 데이터가 없을 때는 정상적인 그래프 형태가 나오지않는 현상이 있습니다. #99
- [개선사항] 로그인 모달을 가운데 정렬 필요 #100
- [FE/BE] 통계 페이지 API 연결 및 월전환에 따른 리렌더링 #76

## 개요

한달 단위로 통계 데이터를 요청할 경우, 기존에는 데이터가 있는 날의 정보만 던져줬는데 원활한 그래프 표현을 위해 비어있는 날이 있더라도 amount 를 0으로 채워서 보내도록 수정했습니다.

그리고 Login Modal 가운데 정렬 처리 (animation문제 인듯)와 차트 그래프의 그리드를 제거하는 옵션을 차트 모듈에 추가했습니다.

## 변경사항

변경사항은 코드 내용이 많지않아서 따로 설명하지않겠습니다.

## 참고사항

달력에서 달을 바꾸고 메인페이지로 이동할경우, Ledger데이터가 정확히 리프레시되는데

통계데이터나 My Wallet Page를 갔다가 메인 혹은 달력 페이지로 갈 경우, 변경된 달의 Ledger가 바로 렌더링 되지않는 버그가 있네요. 어디를 손봐야할 가요? 위치를 알려주시면 제가 해결하겠습니다.



## 추가 구현 필요사항

## 스크린샷

- 그리드 제거한 라인차트 

<img width="716" alt="스크린샷 2021-08-04 오후 6 09 13" src="https://user-images.githubusercontent.com/20085849/128154697-b91de615-34e2-4b7d-8524-f533c06fc60e.png">