### PR TITLE
Line 차트 Y축 레이블을 범위로 보여주도록 수정, 다크모드일 때 차트 색 반영

### DIFF
--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -28,6 +28,8 @@
     width: 300px;
     height: 300px;
     > svg {
+      fill: $text-color;
+      stroke: $text-color;
       width: 100%;
       height: 100%;
     }
@@ -64,8 +66,6 @@
     }
   }
 
-  
-
   #line-chart {
     width: 600px;
     height: 375px;
@@ -74,6 +74,9 @@
       height: 250px;
     }
     > svg {
+      fill: $text-color;
+      stroke: $text-color;
+
       width: 100%;
       height: 100%;
     }

--- a/client/src/utils/charts/PieChart.ts
+++ b/client/src/utils/charts/PieChart.ts
@@ -93,6 +93,7 @@ export default class PieChart {
       textEl.setAttribute('y', (middleY * r).toString());
       textEl.setAttribute('text-anchor', 'middle');
       textEl.setAttribute('font-size', '1.2em');
+      textEl.setAttribute('fill', 'currentColor');
 
       textEl.textContent = entry.name;
       textEl.style.pointerEvents = 'none';


### PR DESCRIPTION
## 개요

다크 모드 일시 차트의 텍스트, 선 색이 변하지않는 부분을 수정했습니다.

Line 차트 Y축 레이블 및 Grid 선을 어떻게 처리할지 고민을 하다가 다음과 같은 공식으로 간격을 생성하도록 했습니다.

```javascript
 caculateGap(range: number) {
    const tempGap = Math.floor(range / this.options.countOfGap!).toString();
    const firstDigit = Number(tempGap[0]);
    const countOfDigit = tempGap.length - 1;
    return firstDigit * Math.pow(10, countOfDigit);
  }
```

숫자의 가장 앞 자리수만 남기고 gap을 지정하는 방식으로 정해놨습니다.

## 변경사항

svg의 css (fill, stroke)의 색상에 color 변수를 활용했습니다.

## 참고사항

## 추가 구현 필요사항

## 스크린샷

- Y축 레이블, gap의 개수를 3개 줬을 때

<img width="146" alt="스크린샷 2021-08-04 오후 11 06 20" src="https://user-images.githubusercontent.com/20085849/128195332-ed797be6-e0eb-40a1-af46-fb2acf82a8f6.png">
