### PR TITLE
[#75] feat : 메인화면 가계부 수정삭제 버튼 추가 및 fe 디자인수정

### DIFF
--- a/client/src/components/Calendar/index.scss
+++ b/client/src/components/Calendar/index.scss
@@ -30,6 +30,7 @@
   .body {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
+    gap: 0.5em;
     border-radius: 0.5em;
     padding: 0;
     margin: 0;
@@ -45,11 +46,21 @@
       padding: 0.4em;
       height: 5em;
       cursor: pointer;
-      border-right: 1px solid $line;
-      border-bottom: 1px solid $line;
+      border: 1px solid $line;
       display: flex;
       flex-direction: column;
       justify-content: space-between;
+      transition: transform 0.5s;
+      background: $background;
+
+      @media (max-width: $tablet-max-width) {
+        height: 4em;
+      }
+
+      &.selected {
+        transform: scale(1.1);
+        box-shadow: 0 0 26px $line;
+      }
 
       > * {
         pointer-events: none;
@@ -58,6 +69,19 @@
       .day-amount {
         text-align: right;
         font-size: 0.9em;
+        div.mobile {
+          display: none;
+        }
+
+        @media (max-width: $tablet-max-width) {
+          div {
+            display: none;
+          }
+          div.mobile {
+            display: block;
+          }
+        }
+
         .income {
           color: $primary;
         }
@@ -78,6 +102,19 @@
       .other {
         opacity: 0.3;
       }
+    }
+  }
+
+  .calendar--footer {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.8em 0.5em;
+    opacity: 0.5;
+    color: $text-color 50%;
+
+    .amouts {
+      display: flex;
+      grid-column-gap: 0.5em;
     }
   }
 }

--- a/client/src/components/Calendar/index.ts
+++ b/client/src/components/Calendar/index.ts
@@ -1,7 +1,9 @@
 import Component from '@/src/core/Component';
-import { ILedgerList } from '@/src/interfaces/Ledger';
+import { ILedger, ILedgerList } from '@/src/interfaces/Ledger';
+import CalendarModel from '@/src/models/Calendar';
+import LedgerDataModel from '@/src/models/Ledgers';
 import { YOIL_ENG_SHORT } from '@/src/utils/calendar';
-import { addComma, html } from '@/src/utils/codeHelper';
+import { addComma, html, sibling } from '@/src/utils/codeHelper';
 import { qs } from '@/src/utils/selectHelper';
 import LedgerList from '../LedgerList';
 import './index.scss';
@@ -9,6 +11,9 @@ import './index.scss';
 interface IState {
   date: Date;
   ledgerData: ILedgerList[] | undefined;
+  totalCount: number;
+  totalIncomes: number;
+  totalSpand: number;
 }
 
 interface IProps {
@@ -16,18 +21,40 @@ interface IProps {
   ledgerData: ILedgerList[] | undefined;
 }
 
+const PREV_MONTHDAY_KEY = 'prev';
+const NEXT_MONTHDAY_KEY = 'next';
+
 export default class Calendar extends Component<IState, IProps> {
   setup() {
     this.$state.ledgerData = this.$props.ledgerData;
     this.$state.date = this.$props.date;
+
+    this.$state.totalIncomes = 0;
+    this.$state.totalSpand = 0;
+    this.$state.ledgerData?.forEach((ledgerList: ILedgerList) => {
+      ledgerList.ledgers.forEach((ledger: ILedger) => {
+        ledger.amount < 0
+          ? ((this.$state.totalSpand as number) += +ledger.amount)
+          : ((this.$state.totalIncomes as number) += +ledger.amount);
+      });
+    });
   }
 
   template() {
-    return `<div class="calendar-container">
-              <ul class="header"></ul>
-              <ul class="body"></ul>
-            </div>
-            <div class="day-ledger-info"></div>`;
+    const { totalIncomes, totalSpand } = this.$state;
+
+    return html`<div class="calendar-container">
+        <ul class="header"></ul>
+        <ul class="body"></ul>
+        <div class="calendar--footer">
+          <div class="amouts">
+            <div>총 수입 : ${'' + totalIncomes}</div>
+            <div>총 지출 : ${'' + totalSpand}</div>
+          </div>
+          <div class="total-amount">총계 : ${'' + (totalIncomes + totalSpand)}</div>
+        </div>
+      </div>
+      <div class="day-ledger-info"></div>`;
   }
 
   mounted() {
@@ -88,11 +115,17 @@ export default class Calendar extends Component<IState, IProps> {
     calendarBody.innerHTML = dates
       .map((day, i) => {
         const condition = i >= firstDateIndex && i < lastDateIndex + 1;
+
         let key: string = '';
         key += viewMonth < 10 ? '0' + viewMonth : viewMonth;
         key += day < 10 ? '0' + day : day;
 
-        return html` <li class="date" ${condition ? `data-key="${key}"` : ''}>
+        if (!condition) {
+          key = i >= firstDateIndex ? NEXT_MONTHDAY_KEY : key;
+          key = i < lastDateIndex + 1 ? PREV_MONTHDAY_KEY : key;
+        }
+
+        return html` <li class="date" data-key="${key}">
           <div ${condition ? '' : 'class="other"'}>${day}</div>
         </li>`;
       })
@@ -103,28 +136,47 @@ export default class Calendar extends Component<IState, IProps> {
     const { ledgerData } = this.$state;
 
     ledgerData?.forEach(ledgerDayData => {
-      const { numDate, income, spand } = ledgerDayData;
+      const { numDate, income, spand, ledgers } = ledgerDayData;
+      let incomeCnt = 0;
+      let spandCnt = 0;
+      ledgers.forEach(ledger => {
+        if (ledger.amount > 0) incomeCnt++;
+        if (ledger.amount < 0) spandCnt++;
+      });
 
       const day = qs(`li[data-key="${numDate}"]`, this.$target) as HTMLElement;
 
       day?.insertAdjacentHTML(
         'beforeend',
-        `<div class="day-amount">
-        <div class="income">${addComma(income)}</div>
-        <div class="spand">${addComma(spand)}</div>
-        <div class="amount">${addComma(spand + income)}</div>
-      </div>`
+        html`<div class="day-amount">
+          <div class="income">${addComma(income)}</div>
+          <div class="spand">${addComma(spand)}</div>
+          <div class="amount">${addComma(spand + income)}</div>
+
+          ${incomeCnt ? `<div class="income mobile"> ${incomeCnt} 건</div>` : ''}
+          ${spandCnt ? `<div class="spand mobile"> ${spandCnt} 건 </div>` : ''}
+        </div>`
       );
     });
   }
 
   showDayLedger(e: MouseEvent) {
     const { ledgerData } = this.$state;
-    const key = (e.target as HTMLElement).dataset.key;
+    const target = e.target as HTMLElement;
+    const key = target.dataset.key;
     const dayLedgerInfo = qs('.day-ledger-info', this.$target) as HTMLElement;
 
+    if (key == PREV_MONTHDAY_KEY) CalendarModel.prevMonth();
+    if (key == NEXT_MONTHDAY_KEY) CalendarModel.nextMonth();
+
+    sibling(target).forEach(el => el.classList.remove('selected'));
+    target.classList.add('selected');
+
     const ledgerList = ledgerData?.find(data => data.numDate == key);
-    if (!ledgerList) return;
+    if (!ledgerList) {
+      dayLedgerInfo.innerHTML = '';
+      return;
+    }
 
     dayLedgerInfo.innerHTML = '';
     new LedgerList(dayLedgerInfo, { ledgerList: ledgerList });

--- a/client/src/components/Calendar/index.ts
+++ b/client/src/components/Calendar/index.ts
@@ -34,8 +34,8 @@ export default class Calendar extends Component<IState, IProps> {
     this.$state.ledgerData?.forEach((ledgerList: ILedgerList) => {
       ledgerList.ledgers.forEach((ledger: ILedger) => {
         ledger.amount < 0
-          ? ((this.$state.totalSpand as number) += +ledger.amount)
-          : ((this.$state.totalIncomes as number) += +ledger.amount);
+          ? ((this.$state.totalSpand) += ledger.amount)
+          : ((this.$state.totalIncomes) += ledger.amount);
       });
     });
   }

--- a/client/src/components/Header/index.scss
+++ b/client/src/components/Header/index.scss
@@ -1,13 +1,14 @@
 @import '../../global.scss';
 
 .header-wrap {
-  // background: $primary;
+  position: relative;
   ul {
     list-style: none;
     display: grid;
     max-width: $pc-max-width;
     justify-content: center;
     align-items: center;
+    position: relative;
     margin: 0 auto;
     padding: 2em;
     grid-template-columns: 1.1fr 0.8fr 1.1fr;
@@ -47,6 +48,25 @@
           font-size: 1.8em;
           font-weight: bold;
         }
+      }
+    }
+  }
+  .theme-changer {
+    position: absolute;
+    top: 1em;
+    right: 2em;
+
+    .theme-changer--button {
+      background: none;
+      font-weight: bold;
+      font-size: 1.5em;
+      border: none;
+      color: $text-color;
+      &.dark:before {
+        content: 'DARK';
+      }
+      &.light:before {
+        content: 'LIGHT';
       }
     }
   }

--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -1,6 +1,5 @@
 import Component from '@/src/core/Component';
 import CalendarModel from '@/src/models/Calendar';
-import LedgerDataModel from '@/src/models/Ledgers';
 import LoginModal from '@/src/components/LoginModal';
 import './index.scss';
 import SvgIcon from '@/src/assets/svg';
@@ -92,7 +91,7 @@ export default class Header extends Component<IState, IProp> {
     let Month: string | string[] | undefined = target.querySelector('.month')?.innerHTML.split('');
     Month?.splice(-1);
     Month = Month?.join('');
-    new MonthPicker(target);
+    new MonthPicker(document.body);
   };
 
   pageRouteClickHandler(e: MouseEvent) {

--- a/client/src/components/LedgerContainer/index.scss
+++ b/client/src/components/LedgerContainer/index.scss
@@ -15,9 +15,9 @@
   }
 
   .fillter {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
     grid-column-gap: 1em;
+
     input[type='checkbox'] {
       position: fixed;
       top: -100vh;
@@ -43,6 +43,7 @@
       position: relative;
       padding-left: 1.5em;
       color: $label;
+
       &:before {
         content: '';
         position: absolute;

--- a/client/src/components/LedgerContainer/index.ts
+++ b/client/src/components/LedgerContainer/index.ts
@@ -61,6 +61,8 @@ export default class LedgerContainer extends Component<IState, IProps> {
     const checkBoxs = [...this.$target.querySelectorAll('input[name="filterCheckbox"]')] as HTMLInputElement[];
     const { ledgerData, checked } = this.$state;
 
+    wrapper.addEventListener('click', this.ledgerButtonsToggleHandler);
+
     //checkBok
     checked?.forEach((id: string) => {
       (this.$target.querySelector(`input#${id}`) as HTMLInputElement).checked = true;
@@ -82,6 +84,13 @@ export default class LedgerContainer extends Component<IState, IProps> {
     ledgerData?.forEach((ledgerList: ILedgerList) => {
       new LedgerList(wrapper, { ledgerList: ledgerList });
     });
+  }
+
+  ledgerButtonsToggleHandler(e: MouseEvent) {
+    const target = e.target as HTMLElement;
+    if (target.nodeName === 'LI') {
+      target.classList.toggle('selected');
+    }
   }
 
   getFilterData(checkBoxs: HTMLInputElement[]) {

--- a/client/src/components/LedgerItem/index.scss
+++ b/client/src/components/LedgerItem/index.scss
@@ -47,10 +47,12 @@ li.ledger-list-item {
     .setting-buttons {
       width: 6em;
       margin-left: 0.5em;
+      transform: translateX(0px);
     }
   }
   .setting-buttons {
     transition: all 0.5s ease-in-out;
+    transform: translateX(10px);
     width: 0;
     transform-origin: right;
 

--- a/client/src/components/LedgerItem/index.scss
+++ b/client/src/components/LedgerItem/index.scss
@@ -1,0 +1,59 @@
+@import '../../global.scss';
+
+li.ledger-list-item {
+  border-bottom: 1px solid $line;
+  display: grid;
+  padding: 0.5em 0;
+  position: relative;
+  grid-template-columns: 5em 3fr 1.5fr 1fr;
+  grid-column-gap: 0.5em;
+  align-items: center;
+  transition: transform 0.3s ease-in-out;
+
+  div {
+    pointer-events: none;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .ledger-category {
+    border-radius: 3em;
+    color: $off-white;
+    padding: 0.3em 0 0.2em;
+    font-size: 0.85em;
+    text-align: center;
+  }
+
+  .ledger-cardType {
+    text-align: center;
+  }
+  .ledger-amount {
+    display: flex;
+    justify-self: flex-end;
+    align-items: center;
+  }
+
+  &.selected {
+    .setting-buttons {
+      width: 6em;
+      margin-left: 0.5em;
+    }
+  }
+  .setting-buttons {
+    transition: all 0.5s ease-in-out;
+    width: 0;
+    transform-origin: right;
+
+    button {
+      padding: 0.5em;
+      background-color: $primary;
+      color: $off-white;
+      border-radius: 0.3em;
+      border: none;
+
+      &:last-child {
+        background-color: $error;
+      }
+    }
+  }
+}

--- a/client/src/components/LedgerItem/index.scss
+++ b/client/src/components/LedgerItem/index.scss
@@ -7,6 +7,7 @@ li.ledger-list-item {
   position: relative;
   grid-template-columns: 5em 3fr 1.5fr 1fr;
   grid-column-gap: 0.5em;
+  min-height: 2.5em;
   align-items: center;
   transition: transform 0.3s ease-in-out;
 
@@ -14,6 +15,15 @@ li.ledger-list-item {
     pointer-events: none;
     white-space: nowrap;
     text-overflow: ellipsis;
+    button {
+      pointer-events: initial;
+    }
+  }
+
+  .ledger-content,
+  .ledger-cardType {
+    white-space: normal;
+    overflow: hidden;
   }
 
   .ledger-category {

--- a/client/src/components/LedgerItem/index.ts
+++ b/client/src/components/LedgerItem/index.ts
@@ -1,6 +1,7 @@
 import Component from '@/src/core/Component';
 import { ILedger } from '@/src/interfaces/Ledger';
 import { addComma, html } from '@/src/utils/codeHelper';
+import './index.scss';
 
 interface IState {
   ledger: ILedger;
@@ -24,11 +25,17 @@ export default class LedgerItem extends Component<IState, IProps> {
     const { name: paymentName } = ledger.paymentType;
 
     return html`
-      <li>
+      <li class="ledger-list-item">
         <div class="ledger-category" style="background: ${categoryColor};">${categoryName}</div>
         <div class="ledger-content">${ledger.content}</div>
         <div class="ledger-cardType">${paymentName}</div>
-        <div class="ledger-amount">${addComma(+ledger.amount)}</div>
+        <div class="ledger-amount">
+          <div>${addComma(+ledger.amount)}</div>
+          <div class="setting-buttons">
+            <button class="edit">수정</button>
+            <button class="delete">삭제</button>
+          </div>
+        </div>
       </li>
     `;
   }

--- a/client/src/components/LedgerItem/index.ts
+++ b/client/src/components/LedgerItem/index.ts
@@ -30,7 +30,7 @@ export default class LedgerItem extends Component<IState, IProps> {
         <div class="ledger-content">${ledger.content}</div>
         <div class="ledger-cardType">${paymentName}</div>
         <div class="ledger-amount">
-          <div>${addComma(+ledger.amount)}</div>
+          <div>${addComma(ledger.amount)}</div>
           <div class="setting-buttons">
             <button class="edit">수정</button>
             <button class="delete">삭제</button>

--- a/client/src/components/LedgerList/index.scss
+++ b/client/src/components/LedgerList/index.scss
@@ -27,69 +27,10 @@
 .ledger-list {
   padding: 0;
   margin-top: 0;
+  cursor: pointer;
   overflow: hidden;
   font-size: 1.2em;
   transition: font-size 0.2s ease-in-out, transform 0.3s ease-in-out;
   transform-origin: top;
   display: grid;
-
-  li {
-    border-bottom: 1px solid $line;
-    display: grid;
-    padding: 1em 0;
-    grid-template-columns: 5em 3fr 1.5fr 1fr;
-    grid-column-gap: 0.5em;
-    align-items: center;
-
-    div {
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-  }
-}
-
-.ledger-category {
-  border-radius: 3em;
-  color: $off-white;
-  padding: 0.3em 0 0.2em;
-  font-size: 0.85em;
-  text-align: center;
-
-  &[data-category-type='1'] {
-    background-color: $category1;
-  }
-  &[data-category-type='2'] {
-    background-color: $category2;
-  }
-  &[data-category-type='3'] {
-    background-color: $category3;
-  }
-  &[data-category-type='4'] {
-    background-color: $category4;
-  }
-  &[data-category-type='5'] {
-    background-color: $category5;
-  }
-  &[data-category-type='6'] {
-    background-color: $category6;
-  }
-  &[data-category-type='7'] {
-    background-color: $category7;
-  }
-  &[data-category-type='8'] {
-    background-color: $category8;
-  }
-  &[data-category-type='9'] {
-    background-color: $category9;
-  }
-  &[data-category-type='10'] {
-    background-color: $category10;
-  }
-}
-
-.ledger-cardType {
-  text-align: center;
-}
-.ledger-amount {
-  justify-self: flex-end;
 }

--- a/client/src/components/LedgerList/index.scss
+++ b/client/src/components/LedgerList/index.scss
@@ -20,6 +20,10 @@
     + .ledger-list {
       font-size: 0;
       transform: scaleY(0);
+
+      button {
+        display: none;
+      }
     }
   }
 }

--- a/client/src/components/LedgerList/index.ts
+++ b/client/src/components/LedgerList/index.ts
@@ -4,6 +4,7 @@ import LedgerItem from '../LedgerItem';
 import { ILedger, ILedgerList } from '@/src/interfaces/Ledger';
 import { YOIL_KOR } from '@/src/utils/calendar';
 import './index.scss';
+import { qs } from '@/src/utils/selectHelper';
 
 interface IState {
   ledgerList: ILedgerList;

--- a/client/src/components/MonthPicker.ts
+++ b/client/src/components/MonthPicker.ts
@@ -36,15 +36,22 @@ export default class MonthPicker {
     return ` 
       .month-calendar-wrapper {
         position: absolute;
-        bottom: 0;
+        top: 0;
         background: var(--background-color);
         padding: .9em;
         left: 50%;
         border-radius: 9px;
         font-size: 16px;
         z-index: 9;
-        transform: translate(-50%, 110%);
+        transform: translate(-50%, 100%);
         box-shadow: 0 3px 5px grey;
+      }
+      .month-calendar-background {
+        top: 0;
+        left: 0;
+        position: fixed;
+        width: 100vw;
+        height: 100vh;
       }
       .month-calendar-wrapper .month-calendar-inner {
         position: relative;
@@ -79,6 +86,7 @@ export default class MonthPicker {
   template() {
     const currentYear = this.date.getFullYear() == this.year;
     return html`
+      <div class="month-calendar-background"></div>
       <div class="month-calendar-wrapper">
         <style>
           ${this.style()}
@@ -111,12 +119,13 @@ export default class MonthPicker {
   render() {
     const MonthPicker = document.querySelector('.month-calendar-wrapper') as HTMLElement;
     MonthPicker?.remove();
-    this.$target.insertAdjacentHTML('afterend', this.template());
+    this.$target.insertAdjacentHTML('beforeend', this.template());
     this.mounted();
   }
 
   mounted() {
     const MonthPicker = document.querySelector('.month-calendar-wrapper') as HTMLElement;
+    const MonthPickerBackground = document.querySelector('.month-calendar-background') as HTMLElement;
     const prev = MonthPicker.querySelector('.prev') as HTMLElement;
     const next = MonthPicker.querySelector('.next') as HTMLElement;
 
@@ -128,7 +137,13 @@ export default class MonthPicker {
       if (target.classList.contains('month')) {
         CalendarModel.setDate(new Date(this.year, Number(target.dataset.monthNumber) - 1, 1));
         MonthPicker.remove();
+        MonthPickerBackground.remove();
       }
+    });
+
+    MonthPickerBackground.addEventListener('click', (e: MouseEvent) => {
+      MonthPicker.remove();
+      MonthPickerBackground.remove();
     });
   }
 }

--- a/client/src/global.scss
+++ b/client/src/global.scss
@@ -171,35 +171,4 @@ html {
   padding: 0.3em 0 0.2em;
   font-size: 0.85em;
   text-align: center;
-
-  &[data-category-type='1'] {
-    background-color: $category1;
-  }
-  &[data-category-type='2'] {
-    background-color: $category2;
-  }
-  &[data-category-type='3'] {
-    background-color: $category3;
-  }
-  &[data-category-type='4'] {
-    background-color: $category4;
-  }
-  &[data-category-type='5'] {
-    background-color: $category5;
-  }
-  &[data-category-type='6'] {
-    background-color: $category6;
-  }
-  &[data-category-type='7'] {
-    background-color: $category7;
-  }
-  &[data-category-type='8'] {
-    background-color: $category8;
-  }
-  &[data-category-type='9'] {
-    background-color: $category9;
-  }
-  &[data-category-type='10'] {
-    background-color: $category10;
-  }
 }

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -7,15 +7,9 @@
     <title>우아한 가계부</title>
   </head>
   <body>
-    <button id="gitOauth">테마토글</button>
-
     <div id="header"></div>
     <div id="app"></div>
-
     <script type="text/javascript">
-      document.getElementById('gitOauth').addEventListener('click', async () => {
-        document.body.classList.toggle('dark-mode');
-      });
     </script>
   </body>
 </html>

--- a/client/src/pages/StatisticPage/index.scss
+++ b/client/src/pages/StatisticPage/index.scss
@@ -10,7 +10,7 @@
   width: 80%;
   border-radius: 8px;
   background-color: $background;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--line-color);
 }
 
 .chart-container {

--- a/client/src/pages/WalletPage/index.scss
+++ b/client/src/pages/WalletPage/index.scss
@@ -2,7 +2,6 @@
 
 .wallet-container {
   position: relative;
-  top: -30px;
   align-items: center;
   height: 500px;
   width: 80%;
@@ -12,7 +11,7 @@
   border-radius: 8px;
 
   background-color: $background;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--line-color);
 }
 
 .wallet-edit-container {
@@ -62,7 +61,7 @@
     box-shadow: -1rem 0 0.2rem rgba(0, 0, 0, 0.5);
     background-color: white;
     transition: 0.2s;
-    animation-name:  fade-in-effect;
+    animation-name: fade-in-effect;
     animation-duration: 0.5s;
     &--name {
       color: black;
@@ -118,8 +117,8 @@
   from {
     opacity: 0.5;
     transform: translate(50%, 0%);
-  } 
-  to{
+  }
+  to {
     transform: translate(0%, 0%);
     opacity: 1;
   }


### PR DESCRIPTION
#75 #81 #82 #83

## 개요
메인화면에서 가계부 수정삭제 버튼 추가해두었습니다.
기능구현은 아직 안되있으므로 api 작성과 연결이 필요합니당

## 변경사항
1. 테마 토글버튼 디자인 변경 및 기능 수정
2. 캘린더 디자인 변경
 - 숫자가 길어지면 화면 너비가 넘어가는 현상때문에
 - 태블릿 미만의 화면 너비에서는 가격이아닌 수입/지출 '건수'로 나타남
3. 캘린더 하단에 총 수입/지출금액 총 합산금액 추가

## 참고사항
## 추가 구현 필요사항
 가계부 조회 수정 api 기능 연결 및 추가

## 스크린샷
![Aug-04-2021 23-42-18](https://user-images.githubusercontent.com/38929712/128201512-3f42a0f4-d123-4e89-9985-9ea87af404d8.gif)


