### PR TITLE
[#75] 가계부 수정관련 API 추가 (Ledger 수정, 삭제, 조회)

### DIFF
--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -8,7 +8,8 @@ const ERROR_PARAMETER_INVALID = '입력 값이 잘못되었습니다.';
 const ERROR_CATEGORY_NOT_FOUND = '카테고리를 찾을 수 없습니다.';
 const ERROR_CREATION_LEDGER_FAIL = '가계부 데이터를 생성하는데 실패했습니다.';
 const ERROR_LEDGER_NOT_FOUND = '가계부 데이터를 조회하는데 실패했습니다.';
-const ERROR_UNAUTHORIZED_LEDGER = '해당 데이터 조회에 대한 권한이 없습니다.';
+const ERROR_UNAUTHORIZED_LEDGER = '가계부 데이터 조회에 대한 권한이 없습니다.';
+const ERROR_UPDATE_LEDGER = '가계부 데이터를 수정하는데 실패했습니다.';
 
 class LedgerController {
   async getLedger(req: Request, res: Response) {
@@ -228,8 +229,96 @@ class LedgerController {
     }
   }
 
-  updateLedger(req: Request, res: Response) {
-    throw new Error('Method not implemented.');
+  async updateLedger(req: Request, res: Response) {
+    const userId = req.user.id!;
+    const { id } = req.params;
+    const idAsNumber = Number(id);
+    const { paymentTypeId, categoryId, date, content, amount } = req.body;
+
+    if (isNaN(idAsNumber)) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(id require number)',
+        })
+        .end();
+      return;
+    }
+    const paymentTypeIdAsNumber = Number(paymentTypeId);
+
+    if (isNaN(paymentTypeIdAsNumber)) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(paymentType id is empty or invalid)',
+        })
+        .end();
+      return;
+    }
+
+    // TODO: payment Type 가 db에 있는 건지 체크 (Payment API 추가해야함.)
+    // TODO: payment Type 이 현재 유저의 결제 타입인지 체크
+
+    const categoryIdAsNumber = Number(categoryId);
+
+    if (isNaN(categoryIdAsNumber)) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(category id is empty or invalid)',
+        })
+        .end();
+      return;
+    }
+
+    const category = await categoryService.getCategory(categoryIdAsNumber);
+    if (!category) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_CATEGORY_NOT_FOUND + `(id:${categoryIdAsNumber}).`,
+        })
+        .end();
+      return;
+    }
+
+    const amountAsNumber = Number(amount);
+
+    if (isNaN(amountAsNumber)) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(amount is invalid)',
+        })
+        .end();
+      return;
+    }
+
+    const ledgerDto: LedgerRequestDTO = {
+      paymentTypeId: paymentTypeIdAsNumber,
+      categoryId: categoryIdAsNumber,
+      date,
+      content,
+      amount: amountAsNumber,
+    };
+
+    const isSuccess = await LedgerService.updateLedger(idAsNumber, ledgerDto, userId);
+    if (isSuccess) {
+      res
+        .status(SUCCESS)
+        .send({
+          success: true,
+        })
+        .end();
+    } else {
+      res
+        .status(SUCCESS)
+        .send({
+          success: false,
+          error: ERROR_UPDATE_LEDGER,
+        })
+        .end();
+    }
   }
 }
 

--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { BAD_REQUEST, SERVER_ERROR } from '../utils/HttpStatus';
+import { BAD_REQUEST, NOT_FOUND, SERVER_ERROR, SUCCESS } from '../utils/HttpStatus';
 import { LedgerRequestDTO, LedgerResponseDTO } from '../dto/LedgerDTO';
 import LedgerService from '../services/ledger.service';
 import categoryService from '../services/category.service';
@@ -7,8 +7,54 @@ import categoryService from '../services/category.service';
 const ERROR_PARAMETER_INVALID = '입력 값이 잘못되었습니다.';
 const ERROR_CATEGORY_NOT_FOUND = '카테고리를 찾을 수 없습니다.';
 const ERROR_CREATION_LEDGER_FAIL = '가계부 데이터를 생성하는데 실패했습니다.';
+const ERROR_LEDGER_NOT_FOUND = '가계부 데이터를 조회하는데 실패했습니다.';
 
 class LedgerController {
+  deleteLedger(req: Request, res: Response) {
+    throw new Error('Method not implemented.');
+  }
+
+  updateLedger(req: Request, res: Response) {
+    throw new Error('Method not implemented.');
+  }
+
+  async getLedger(req: Request, res: Response) {
+    const userId = req.user.id!;
+    const { id } = req.params;
+    const idAsNumber = Number(id);
+
+    if (isNaN(idAsNumber)) {
+      res
+        .status(BAD_REQUEST)
+        .send({
+          error: ERROR_PARAMETER_INVALID + '(id require number)',
+        })
+        .end();
+      return;
+    }
+
+    const ledger = await LedgerService.getLedger(idAsNumber);
+    if (ledger) {
+      res
+        .status(SUCCESS)
+        .send({
+          success: true,
+          data: ledger,
+        })
+        .end();
+    } else {
+      res
+        .status(NOT_FOUND)
+        .send({
+          error: ERROR_LEDGER_NOT_FOUND,
+        })
+        .end();
+    }
+    // User가 해당 id의 Ledger를 가지고 있는지 체크하면서 동시에 ledger 유무 확인
+    // 사실 query날리면서 증명된다.
+    // 있는지 없는지만 체크해서 처리하자.
+  }
+
   async getLedgersByDate(req: Request, res: Response) {
     const queryDate = req.query.date as string;
     const date = new Date(queryDate);

--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -312,7 +312,7 @@ class LedgerController {
         .end();
     } else {
       res
-        .status(SUCCESS)
+        .status(SERVER_ERROR)
         .send({
           success: false,
           error: ERROR_UPDATE_LEDGER,

--- a/server/src/mapper/ledger.mapper.ts
+++ b/server/src/mapper/ledger.mapper.ts
@@ -1,0 +1,40 @@
+import Ledger from '../models/ledger.model';
+import { CategoryResponseDTO } from '../dto/CategoryDTO';
+import { PaymentTypeResponseDTO } from '../dto/PaymentTypeDTO';
+import { LedgerResponseDTO } from '../dto/LedgerDTO';
+
+export const ledgerToLedgerResponseDTO = (ledger: Ledger): LedgerResponseDTO => {
+  const { id, userId, paymentTypeId, paymentType, categoryId, category, amount, date, content } = ledger;
+  if (!category) {
+    throw new Error('category가 존재하지않는 ledger 데이터가 존재합니다.');
+  }
+
+  const categoryDTO: CategoryResponseDTO = {
+    id: category.id!,
+    name: category.name,
+    color: category.color,
+  };
+
+  if (!paymentType) {
+    throw new Error('paymentType이 존재하지않는 Ledger 데이터가 존재합니다.');
+  }
+
+  const paymentTypeDTO: PaymentTypeResponseDTO = {
+    id: paymentType.id!,
+    name: paymentType.name,
+    bgColor: paymentType.bgColor,
+    fontColor: paymentType.bgColor,
+  };
+
+  return {
+    id: id!,
+    userId: userId!,
+    paymentTypeId: paymentTypeId!,
+    paymentType: paymentTypeDTO,
+    categoryId: categoryId!,
+    category: categoryDTO,
+    date: date!,
+    content: content!,
+    amount: amount!,
+  };
+};

--- a/server/src/repositories/ledger.repository.ts
+++ b/server/src/repositories/ledger.repository.ts
@@ -67,10 +67,45 @@ class LedgerRepository {
 
   /**
    * id를 이용해서 Ledger 삭제
+   * * @param id Ledger Id
    */
   async deleteLedger(id: number): Promise<number> {
     const countOfDeleted = await Ledger.destroy({ where: { id } });
     return countOfDeleted;
+  }
+
+  /**
+   * Ledger를 변경하는 API
+   * @param userId 유저의 고유 식별자(id)
+   * @param categoryId 카테고리의 고유 식별자(id)
+   * @param content Ledger의 내용
+   * @param amount Ledger의 비용
+   * @param date Ledger의 생성 일자
+   * @returns 생성된 Ledger 데이터의 id
+   */
+  async updateLedger(
+    id: number,
+    userId: number,
+    categoryId: number,
+    paymentTypeId: number,
+    content: string,
+    amount: number,
+    date: string
+  ): Promise<Ledger> {
+    const originLedger = await Ledger.findOne({
+      where: { id },
+    });
+
+    if (!originLedger) throw Error('not exist ledger');
+
+    originLedger.userId = userId;
+    originLedger.paymentTypeId = paymentTypeId;
+    originLedger.categoryId = categoryId;
+    originLedger.date = date;
+    originLedger.content = content;
+    originLedger.amount = amount;
+
+    return originLedger.save();
   }
 }
 

--- a/server/src/repositories/ledger.repository.ts
+++ b/server/src/repositories/ledger.repository.ts
@@ -11,14 +11,8 @@ class LedgerRepository {
    */
   async userLedgersByMonth(startDate: Date, endDate: Date, userId: number): Promise<Ledger[]> {
     const Ledgers = await Ledger.findAll({
-      include: [
-        Ledger.associations.category,
-        Ledger.associations.user,
-        Ledger.associations.paymentType
-      ],
-      order: [
-        ['date', 'ASC']
-      ],
+      include: [Ledger.associations.category, Ledger.associations.user, Ledger.associations.paymentType],
+      order: [['date', 'ASC']],
       where: {
         userId: userId,
         date: { [Op.between]: [startDate, endDate] },
@@ -37,20 +31,38 @@ class LedgerRepository {
    * @param date Ledger의 생성 일자
    * @returns 생성된 Ledger 데이터의 id
    */
-  async createLedger(userId: number, categoryId: number, paymentTypeId: number, content: string, amount: number, date: string): Promise<number | null> {
+  async createLedger(
+    userId: number,
+    categoryId: number,
+    paymentTypeId: number,
+    content: string,
+    amount: number,
+    date: string
+  ): Promise<number | null> {
     const newLedger = await Ledger.create<Ledger>({
       userId,
       paymentTypeId,
       categoryId,
       date,
       content,
-      amount
+      amount,
     });
     if (newLedger) {
       return newLedger.id!;
     } else {
       return null;
     }
+  }
+
+  /**
+   * 하나의 Ledger를 조회하는 API
+   * @param id Ledger Id
+   */
+  async getLedger(id: number): Promise<Ledger | null> {
+    return await Ledger.findOne({
+      include: [Ledger.associations.category, Ledger.associations.paymentType, Ledger.associations.user],
+      where: { id },
+    });
   }
 }
 

--- a/server/src/repositories/ledger.repository.ts
+++ b/server/src/repositories/ledger.repository.ts
@@ -64,6 +64,14 @@ class LedgerRepository {
       where: { id },
     });
   }
+
+  /**
+   * id를 이용해서 Ledger 삭제
+   */
+  async deleteLedger(id: number): Promise<number> {
+    const countOfDeleted = await Ledger.destroy({ where: { id } });
+    return countOfDeleted;
+  }
 }
 
 const ledgerRepository = new LedgerRepository();

--- a/server/src/router/ledger.router.ts
+++ b/server/src/router/ledger.router.ts
@@ -21,14 +21,29 @@ ledgerRouter.get('/day', authJWT, wrapAsync(LedgerController.getLedgersGroupByDa
  * GET /api/ledger/statistic
  * 통계를 위한 Ledger Data를 반환해줍니다.
  */
-ledgerRouter.get("/statistic", authJWT, wrapAsync(LedgerController.getStatisticLedgersByDate));
+ledgerRouter.get('/statistic', authJWT, wrapAsync(LedgerController.getStatisticLedgersByDate));
 
 /**
  * POST /api/ledger
- * 새로운 가계부 데이터 추가 
+ * 새로운 가계부 데이터 추가
  */
 ledgerRouter.post('/', authJWT, wrapAsync(LedgerController.createLedger));
 
+/**
+ * GET /api/ledger/:id
+ * Ledger Id를 이용해서 Ledger를 조회합니다.
+ */
+ledgerRouter.get('/:id', authJWT, wrapAsync(LedgerController.getLedger));
 
+/**
+ * PUT /api/ledger/:id
+ * Ledger API
+ */
+ledgerRouter.put('/:id', authJWT, wrapAsync(LedgerController.updateLedger));
+
+/**
+ * DELETE /api/ledger/:id
+ */
+ledgerRouter.delete('/:id', authJWT, wrapAsync(LedgerController.deleteLedger));
 
 export default ledgerRouter;

--- a/server/src/services/ledger.service.ts
+++ b/server/src/services/ledger.service.ts
@@ -1,4 +1,3 @@
-import { CategoryResponseDTO } from '../dto/CategoryDTO';
 import {
   LedgerRequestDTO,
   LedgerResponseDTO,
@@ -6,55 +5,22 @@ import {
   StatisticEntry,
   StatisticLedgersResponseDTO,
 } from '../dto/LedgerDTO';
-import { PaymentTypeResponseDTO } from '../dto/PaymentTypeDTO';
+import { ledgerToLedgerResponseDTO } from '../mapper/ledger.mapper';
 import LedgerRepository from '../repositories/ledger.repository';
 import { range } from '../utils/arrayHelper';
 import { days } from '../utils/dayHelper';
-import categoryService from './category.service';
 
 class LedgerService {
+  async getLedger(id: number): Promise<LedgerResponseDTO | null> {
+    const ledger = await LedgerRepository.getLedger(id);
+    return ledger ? ledgerToLedgerResponseDTO(ledger) : null;
+  }
+
   async getLedgersByMonth(date: Date, userId: number): Promise<LedgerResponseDTO[]> {
     const startDate = date;
     const endDate = new Date(date.getFullYear(), date.getMonth() + 1, 0);
-
     const ledgers = await LedgerRepository.userLedgersByMonth(startDate, endDate, userId);
-
-    const ledgerDTOs: LedgerResponseDTO[] = ledgers.map(ledger => {
-      const { id, userId, paymentTypeId, paymentType, categoryId, category, amount, date, content } = ledger;
-      if (!category) {
-        throw new Error('category가 존재하지않는 ledger 데이터가 존재합니다.');
-      }
-
-      const categoryDTO: CategoryResponseDTO = {
-        id: category.id!,
-        name: category.name,
-        color: category.color,
-      };
-
-      if (!paymentType) {
-        throw new Error('paymentType이 존재하지않는 Ledger 데이터가 존재합니다.');
-      }
-
-      const paymentTypeDTO: PaymentTypeResponseDTO = {
-        id: paymentType.id!,
-        name: paymentType.name,
-        bgColor: paymentType.bgColor,
-        fontColor: paymentType.bgColor,
-      };
-
-      return {
-        id: id!,
-        userId: userId!,
-        paymentTypeId: paymentTypeId!,
-        paymentType: paymentTypeDTO,
-        categoryId: categoryId!,
-        category: categoryDTO,
-        date: date!,
-        content: content!,
-        amount: amount!,
-      };
-    });
-
+    const ledgerDTOs: LedgerResponseDTO[] = ledgers.map(ledger => ledgerToLedgerResponseDTO(ledger));
     return ledgerDTOs;
   }
 

--- a/server/src/services/ledger.service.ts
+++ b/server/src/services/ledger.service.ts
@@ -11,8 +11,8 @@ import { range } from '../utils/arrayHelper';
 import { days } from '../utils/dayHelper';
 
 class LedgerService {
-  async deleteLedger(idAsNumber: number): Promise<boolean> {
-    const countOfRemoveRows = await LedgerRepository.deleteLedger(idAsNumber);
+  async deleteLedger(id: number): Promise<boolean> {
+    const countOfRemoveRows = await LedgerRepository.deleteLedger(id);
     return countOfRemoveRows > 0;
   }
 
@@ -37,6 +37,17 @@ class LedgerService {
       return newLedgerId;
     } else {
       return null;
+    }
+  }
+
+  async updateLedger(id: number, ledgerDto: LedgerRequestDTO, userId: number): Promise<boolean> {
+    const { categoryId, paymentTypeId, date, content, amount } = ledgerDto;
+    try {
+      await LedgerRepository.updateLedger(id, userId, categoryId, paymentTypeId, content, amount, date);
+      return true;
+    } catch (error) {
+      console.error(error); // TODO: change logger
+      return false;
     }
   }
 

--- a/server/src/services/ledger.service.ts
+++ b/server/src/services/ledger.service.ts
@@ -11,6 +11,11 @@ import { range } from '../utils/arrayHelper';
 import { days } from '../utils/dayHelper';
 
 class LedgerService {
+  async deleteLedger(idAsNumber: number): Promise<boolean> {
+    const countOfRemoveRows = await LedgerRepository.deleteLedger(idAsNumber);
+    return countOfRemoveRows > 0;
+  }
+
   async getLedger(id: number): Promise<LedgerResponseDTO | null> {
     const ledger = await LedgerRepository.getLedger(id);
     return ledger ? ledgerToLedgerResponseDTO(ledger) : null;


### PR DESCRIPTION
[BE/FE] 가계부 수정 기능완성 #75

## 개요

- `GET /api/ledger/[id]` 조회 (수정하기전 이전 데이터 가져오기 위해 사용)
- `DELETE /api/ledger/[id]` 삭제 (삭제 버튼 클릭시 삭제)
- `PUT /api/ledger/[id]` 수정 (수정 모달에서 수정했을 때 호출)

## 변경사항

위키에 문서를 전체적으로 수정해두겠습니다.

API 사용 법은 WIKI 참조하시면 될 것 같습니다. [문서링크](https://github.com/woowa-techcamp-2021/cashbook-5/wiki/Ledger-API-%EC%A0%95%EB%A6%AC)

## 참고사항

## 추가 구현 필요사항

## 스크린샷
