### PR TITLE
[#117]fix: 지출 내역 음수인 데이터만으로 통계 데이터 생성

### DIFF
--- a/server/src/controllers/ledger.controller.ts
+++ b/server/src/controllers/ledger.controller.ts
@@ -79,11 +79,11 @@ class LedgerController {
     });
   }
 
-  async getStatisticLedgersByDate(req: Request, res: Response) {
+  async getStatisticExpenseLedgersByDate(req: Request, res: Response) {
     const queryDate = req.query.date as string;
     const date = new Date(queryDate);
     const userId = req.user.id!;
-    const ledgers: LedgerResponseDTO[] = await LedgerService.getLedgersByMonth(date, userId);
+    const ledgers: LedgerResponseDTO[] = await LedgerService.getExpenseLedgersByMonth(date, userId);
     const statisticLedgers = LedgerService.convertToStatisticLedgers(ledgers, date);
 
     res.send({

--- a/server/src/repositories/ledger.repository.ts
+++ b/server/src/repositories/ledger.repository.ts
@@ -3,7 +3,7 @@ import Ledger from '../models/ledger.model';
 
 class LedgerRepository {
   /**
-   * Get Ledgers (between startDate and endDate)
+   * Get All Ledgers between startDate and endDate
    * @param startDate Date
    * @param endDate Date
    * @param userId number
@@ -15,6 +15,27 @@ class LedgerRepository {
       order: [['date', 'ASC']],
       where: {
         userId: userId,
+        date: { [Op.between]: [startDate, endDate] },
+      },
+    });
+
+    return Ledgers;
+  }
+
+  /**
+   * Get All Ledgers between startDate and endDate
+   * @param startDate Date
+   * @param endDate Date
+   * @param userId number
+   * @returns  Promise<Ledger[]>
+   */
+  async userExpenseLedgersByMonth(startDate: Date, endDate: Date, userId: number): Promise<Ledger[]> {
+    const Ledgers = await Ledger.findAll({
+      include: [Ledger.associations.category, Ledger.associations.user, Ledger.associations.paymentType],
+      order: [['date', 'ASC']],
+      where: {
+        userId: userId,
+        amount: { [Op.lt]: [0] },
         date: { [Op.between]: [startDate, endDate] },
       },
     });

--- a/server/src/router/ledger.router.ts
+++ b/server/src/router/ledger.router.ts
@@ -21,7 +21,7 @@ ledgerRouter.get('/day', authJWT, wrapAsync(LedgerController.getLedgersGroupByDa
  * GET /api/ledger/statistic
  * 통계를 위한 Ledger Data를 반환해줍니다.
  */
-ledgerRouter.get('/statistic', authJWT, wrapAsync(LedgerController.getStatisticLedgersByDate));
+ledgerRouter.get('/statistic', authJWT, wrapAsync(LedgerController.getStatisticExpenseLedgersByDate));
 
 /**
  * POST /api/ledger

--- a/server/src/services/ledger.service.ts
+++ b/server/src/services/ledger.service.ts
@@ -29,6 +29,14 @@ class LedgerService {
     return ledgerDTOs;
   }
 
+  async getExpenseLedgersByMonth(date: Date, userId: number): Promise<LedgerResponseDTO[]> {
+    const startDate = date;
+    const endDate = new Date(date.getFullYear(), date.getMonth() + 1, 0);
+    const ledgers = await LedgerRepository.userExpenseLedgersByMonth(startDate, endDate, userId);
+    const ledgerDTOs: LedgerResponseDTO[] = ledgers.map(ledger => ledgerToLedgerResponseDTO(ledger));
+    return ledgerDTOs;
+  }
+
   async createLedger(ledgerDto: LedgerRequestDTO, userId: number): Promise<number | null> {
     const { categoryId, paymentTypeId, date, content, amount } = ledgerDto;
 
@@ -124,12 +132,12 @@ class LedgerService {
       const entries: StatisticEntry[] = Array.from(dayAndAmountMap.entries()).map(([date, amountOfDay]) => {
         return {
           datetime: new Date(date),
-          amount: amountOfDay,
+          amount: Math.abs(amountOfDay),
         };
       });
 
       statisticLedgers[categoryName] = {
-        total,
+        total: Math.abs(total),
         color,
         entries,
       };


### PR DESCRIPTION
그래프에 음수 데이터가 있을 경우 이상한 랜더링 #117

## 개요

지출 내역이 기존에는 양수, 음수 데이터들이 모두 보여졌는데 통계 데이터를 호출하는 API 에서 수정을 했습니다.

## 변경사항

repository 수준에서 음수인 데이터만 가져와서 통계데이터를 전처리하는 과정에 Math.abs를 적용해줬습니다.


## 참고사항

## 추가 구현 필요사항

## 스크린샷
