### PR TITLE
[#124] UX 개선작업 진행 (가계부 입력 화면에서 수입/지출 라디오 버튼 추가)

### DIFF
--- a/client/src/components/Header/index.ts
+++ b/client/src/components/Header/index.ts
@@ -78,7 +78,8 @@ export default class Header extends Component<IState, IProp> {
     const themeToggleButton = qs('.theme-changer--button', this.$target) as HTMLElement;
     dataWrap.addEventListener('click', () => this.showMonthPiceker(dataWrap));
 
-    (iconsWrap.querySelector(`[data-page="${location.pathname}"]`) as HTMLElement).classList.add('selected');
+    const selectedIconsWrap = iconsWrap.querySelector(`[data-page="${location.pathname}"]`) as HTMLElement;
+    selectedIconsWrap?.classList.add('selected');
     //router
     iconsWrap.addEventListener('click', this.pageRouteClickHandler);
     logoPageRouters.addEventListener('click', this.pageRouteClickHandler);

--- a/client/src/components/LedgerAddModal/index.scss
+++ b/client/src/components/LedgerAddModal/index.scss
@@ -39,6 +39,7 @@
     width: 100%;
     flex-basis: 4.4em;
     display: flex;
+    align-items: center;
     background-color: transparent;
     & > label {
       flex-basis: 4em;
@@ -127,4 +128,26 @@
 #card-type-selector-container {
   display: flex;
   align-content: center;
+}
+
+.amount-type-selector {
+  display: flex;
+  width: 8em;
+  height: 100%;
+  justify-content: space-between;
+  &--btn {
+    display: flex;
+    justify-content: center;
+    border-radius: 8px;
+    padding: 0.5em 1em;
+    user-select: none;
+    cursor: pointer;
+    color: $primary;
+    border: 1px solid $primary;
+    background-color: transparent;
+    &.select {
+      background-color: $primary;
+      color: $off-white;
+    }
+  }
 }

--- a/client/src/components/LedgerAddModal/index.ts
+++ b/client/src/components/LedgerAddModal/index.ts
@@ -5,7 +5,7 @@ import { addComma, convertToYYYYMMDD, html } from '@/src/utils/codeHelper';
 import CategorySelector from './CategorySelector';
 import CardTypeSelector from './CardTypeSelector';
 import Snackbar from '../SnackBar';
-import { createLedgerData, editLedgerData, getLedgerData } from '@/src/api/ledgerAPI';
+import { createLedgerData, editLedgerData } from '@/src/api/ledgerAPI';
 import calendarModel from '@/src/models/Calendar';
 import { ILedger } from '@/src/interfaces/Ledger';
 
@@ -39,6 +39,7 @@ interface IProps {}
 
 export default class LedgerAddModal extends Component<IState, IProps> {
   setup() {
+    this.$state.isExpenseAmount = true;
     this.$state.ledger = this.$props.ledger;
     if (this.$state.ledger) {
       this.$state.paymentTypeId = this.$state.ledger.paymentType.id;
@@ -59,7 +60,8 @@ export default class LedgerAddModal extends Component<IState, IProps> {
       categoryName = ledger.category.name;
       content = ledger.content;
       paymentName = ledger.paymentType.name;
-      amount = ledger.amount;
+      amount = Math.abs(ledger.amount);
+      this.$state.isExpenseAmount = ledger.amount < 0;
     } else {
       date = convertToYYYYMMDD(new Date());
     }

--- a/client/src/components/LedgerAddModal/index.ts
+++ b/client/src/components/LedgerAddModal/index.ts
@@ -8,6 +8,7 @@ import Snackbar from '../SnackBar';
 import { createLedgerData, editLedgerData, getLedgerData } from '@/src/api/ledgerAPI';
 import calendarModel from '@/src/models/Calendar';
 import { ILedger } from '@/src/interfaces/Ledger';
+import { UsageState } from 'webpack';
 
 const MAX_AMOUNT = 100000000;
 const MIN_AMOUNT = -100000000;
@@ -51,12 +52,15 @@ export default class LedgerAddModal extends Component<IState, IProps> {
       content = '',
       paymentName = '',
       amount = 0;
+
     if (ledger) {
       date = ledger.date!;
       categoryName = ledger.category.name;
       content = ledger.content;
       paymentName = ledger.paymentType.name;
       amount = ledger.amount;
+    } else {
+      date = convertToYYYYMMDD(new Date());
     }
 
     return html`
@@ -255,5 +259,8 @@ export default class LedgerAddModal extends Component<IState, IProps> {
 
   show() {
     this.$target.style.display = 'flex';
+    this.setState({
+      ...this.$state,
+    });
   }
 }

--- a/client/src/components/PaymentTypeAddModal/index.ts
+++ b/client/src/components/PaymentTypeAddModal/index.ts
@@ -36,14 +36,16 @@ interface IProps {}
 export default class PaymentTypeAddModal extends Component<IState, IProps> {
   setup() {
     this.$state = {
-      bgColor: '',
-      fontColor: '',
+      bgColor: backgroundColors[0],
+      fontColor: fontColors[0],
       name: '',
       error: {},
     };
   }
+
   template() {
     const { error, name, fontColor, bgColor } = this.$state;
+    console.log(fontColor);
     return html`
       <div class="blur-background"></div>
       <div class="payment-type-modal">
@@ -77,7 +79,7 @@ export default class PaymentTypeAddModal extends Component<IState, IProps> {
             ${fontColors
               .map(
                 color => html`
-                  <li class="color-picker--item" data-color="${color}">
+                  <li class="color-picker--item ${fontColor === color ? 'select' : ''}" data-color="${color}">
                     <div class="box" style="background-color:${color}"></div>
                   </li>
                 `
@@ -209,8 +211,8 @@ export default class PaymentTypeAddModal extends Component<IState, IProps> {
 
   clear() {
     this.setState({
-      bgColor: '',
-      fontColor: '',
+      bgColor: backgroundColors[0],
+      fontColor: fontColors[0],
       name: '',
       error: {},
     });

--- a/client/src/components/PaymentTypeAddModal/index.ts
+++ b/client/src/components/PaymentTypeAddModal/index.ts
@@ -45,7 +45,6 @@ export default class PaymentTypeAddModal extends Component<IState, IProps> {
 
   template() {
     const { error, name, fontColor, bgColor } = this.$state;
-    console.log(fontColor);
     return html`
       <div class="blur-background"></div>
       <div class="payment-type-modal">

--- a/client/src/pages/WalletPage/index.scss
+++ b/client/src/pages/WalletPage/index.scss
@@ -28,11 +28,6 @@
     color: $primary;
     user-select: none;
 
-    &:hover {
-      color: $off-white;
-      background-color: $primary;
-    }
-
     &:not(:first-child) {
       margin-left: 1em;
     }

--- a/client/src/pages/WalletPage/index.ts
+++ b/client/src/pages/WalletPage/index.ts
@@ -13,12 +13,12 @@ interface IState {
   $editButton?: HTMLElement;
 }
 
-interface IProps { }
+interface IProps {}
 
 const EDIT_MODE_ON_STRING = '수정 하기';
-const EDIT_MODE_OFF_STRING = '수정 중';
+const EDIT_MODE_OFF_STRING = '수정 확인';
 
-const PAYMENT_TYPE_LIST_OBSERVER_LISTENER_KEY = "wallet";
+const PAYMENT_TYPE_LIST_OBSERVER_LISTENER_KEY = 'wallet';
 
 export default class WalletPage extends Component<IState, IProps> {
   template() {
@@ -51,8 +51,6 @@ export default class WalletPage extends Component<IState, IProps> {
       }
     });
   }
-
-
 
   mounted() {
     this.$state.$editButton = qs('#edit-mode-toggle-btn', this.$target) as HTMLElement;
@@ -94,9 +92,9 @@ export default class WalletPage extends Component<IState, IProps> {
     }
 
     // deletgate item delete event
-    const $cardList = qs(".card-list", this.$target) as HTMLElement;
-    $cardList.addEventListener("click", (e: MouseEvent) => {
-      const cardDeleteBtns = qsAll(".card-list--item--delete-btn", $cardList);
+    const $cardList = qs('.card-list', this.$target) as HTMLElement;
+    $cardList.addEventListener('click', (e: MouseEvent) => {
+      const cardDeleteBtns = qsAll('.card-list--item--delete-btn', $cardList);
       const target = e.target as HTMLElement;
       for (const btn of cardDeleteBtns) {
         if (target === btn) {
@@ -104,7 +102,7 @@ export default class WalletPage extends Component<IState, IProps> {
           this.handleCardDeleteBtnClickEvent(paymentTypeId);
         }
       }
-    })
+    });
   }
 
   async handleCardDeleteBtnClickEvent(id: number) {
@@ -161,7 +159,6 @@ export default class WalletPage extends Component<IState, IProps> {
     this.$state.paymentTypes = newPaymentTypes;
     this.renderCardItems();
     this.updateEditButton(this.$state.isEditMode);
-
   }
 
   setUnmount() {
@@ -169,7 +166,10 @@ export default class WalletPage extends Component<IState, IProps> {
   }
 
   setEvent() {
-    paymentTypeListModel.subscribe(PAYMENT_TYPE_LIST_OBSERVER_LISTENER_KEY, this.paymentTypeListModelSubscribeFunction.bind(this));
+    paymentTypeListModel.subscribe(
+      PAYMENT_TYPE_LIST_OBSERVER_LISTENER_KEY,
+      this.paymentTypeListModelSubscribeFunction.bind(this)
+    );
     this.resetEvent();
   }
 }

--- a/client/src/pages/WalletPage/index.ts
+++ b/client/src/pages/WalletPage/index.ts
@@ -15,8 +15,8 @@ interface IState {
 
 interface IProps {}
 
-const EDIT_MODE_ON_STRING = '수정 하기';
-const EDIT_MODE_OFF_STRING = '수정 확인';
+const EDIT_MODE_ON_STRING = '수정';
+const EDIT_MODE_OFF_STRING = '확인';
 
 const PAYMENT_TYPE_LIST_OBSERVER_LISTENER_KEY = 'wallet';
 


### PR DESCRIPTION

[UX] UX 개선 사항 #124

## 개요

지인에게 피드백받은 UX 개선사항들을 업데이트 했습니다.

- 수입 지출을 마이너스를 붙이는게 어색하다. 거의 사람들이 뭐가 지출이고 수입인지 모를듯하다.
- 결제수단이 없을 경우, default 값이나 어떻게 추가하는지 알려주면 좋을 듯 (아직 미구현)

메인에 스낵바는 함부로 지우기보다는 한철님과 얘기하고 수정하는게 좋을 것같아 아직남겼습니다.


## 변경사항

## 참고사항

## 추가 구현 필요사항

## 스크린샷

<img width="540" alt="스크린샷 2021-08-06 오전 12 11 37" src="https://user-images.githubusercontent.com/20085849/128375592-7356e9b1-8111-4323-af4c-03bac71802d4.png">

